### PR TITLE
Added an option to always display pagination

### DIFF
--- a/lib/will_paginate/view_helpers.rb
+++ b/lib/will_paginate/view_helpers.rb
@@ -30,7 +30,8 @@ module WillPaginate
       :params         => nil,
       :renderer       => nil,
       :page_links     => true,
-      :container      => true
+      :container      => true,
+      :show_always    => false
     }
 
     include WillPaginate::I18n
@@ -54,6 +55,8 @@ module WillPaginate
     # * <tt>:page_links</tt> -- when false, only previous/next links are rendered (default: true)
     # * <tt>:container</tt> -- toggles rendering of the DIV container for pagination links, set to
     #   false only when you are rendering your own pagination markup (default: true)
+    # * <tt>:show_always</tt> -- when true, display the pagination even if
+    #   there is not more than one page (default: false)
     #
     # All options not recognized by will_paginate will become HTML attributes on the container
     # element for pagination links (the DIV). For example:
@@ -66,7 +69,7 @@ module WillPaginate
     #
     def will_paginate(collection, options = {})
       # early exit if there is nothing to render
-      return nil unless collection.total_pages > 1
+      return nil unless collection.total_pages > 1 || options[:show_always]
 
       options = WillPaginate::ViewHelpers.pagination_options.merge(options)
 

--- a/spec/view_helpers/base_spec.rb
+++ b/spec/view_helpers/base_spec.rb
@@ -32,6 +32,16 @@ describe WillPaginate::ViewHelpers do
       collection = mock 'Collection', :total_pages => 1
       will_paginate(collection).should be_nil
     end
+
+    it "should render for single-page collections if :show_always is set" do
+      collection = mock 'Collection', :total_pages => 1
+      renderer   = mock 'Renderer'
+      renderer.expects(:prepare).with(collection, instance_of(Hash), self)
+      renderer.expects(:to_html).returns('<PAGES>')
+
+      will_paginate(collection, :renderer => renderer, :show_always => true).
+        should == '<PAGES>'
+    end
   end
   
   describe "page_entries_info" do


### PR DESCRIPTION
To increase consistency of page layouts &ndash; even if there's only one page &ndash; it is handy to display pagination always. I added an option called `:show_always` that can be used for that purpose.

Example:
    <%= will_paginate @collection, :show_always => true %>
