### PR TITLE
Use ActiveSupport.on_load in Railtie

### DIFF
--- a/lib/will_paginate/railtie.rb
+++ b/lib/will_paginate/railtie.rb
@@ -4,21 +4,23 @@ require 'will_paginate/collection'
 module WillPaginate
   class Railtie < Rails::Railtie
     initializer "will_paginate.active_record" do |app|
-      if defined? ::ActiveRecord
+      ActiveSupport.on_load :active_record do
         require 'will_paginate/finders/active_record'
         WillPaginate::Finders::ActiveRecord.enable!
       end
     end
     
     initializer "will_paginate.action_dispatch" do |app|
-      if defined? ::ActionDispatch::ShowExceptions
+      ActiveSupport.on_load :action_controller do
         ActionDispatch::ShowExceptions.rescue_responses['WillPaginate::InvalidPage'] = :not_found
       end
     end
     
     initializer "will_paginate.action_view" do |app|
-      require 'will_paginate/view_helpers/action_view'
-      ActionView::Base.send(:include, WillPaginate::ViewHelpers::ActionView)
+      ActiveSupport.on_load :action_view do
+        require 'will_paginate/view_helpers/action_view'
+        include WillPaginate::ViewHelpers::ActionView
+      end
     end
   end
 end


### PR DESCRIPTION
Adding will_paginate to an empty Rails 3 project causes Rails's autoloading framework to be triggered. Modifying railtie.rb a bit to use ActiveSupport.on_load fixes this problem.
