### PR TITLE
paginated_section isn't safe

### DIFF
--- a/lib/will_paginate/view_helpers.rb
+++ b/lib/will_paginate/view_helpers.rb
@@ -140,7 +140,7 @@ module WillPaginate
     # apply. Don't use the <tt>:id</tt> option; otherwise you'll finish with two
     # blocks of pagination links sharing the same ID (which is invalid HTML).
     def paginated_section(*args, &block)
-      pagination = will_paginate(*args).to_s
+      pagination = will_paginate(*args).to_s.html_safe
       
       unless ActionView::Base.respond_to? :erb_variable
         concat pagination


### PR DESCRIPTION
When using the latest rails3 branch of WP, paginated_section isn't html safe.  Simple fix to make it so.  Please let me know if I've just missed something silly here..?
