### PR TITLE
Rails 3 paginated_section with no pages

### DIFF
--- a/lib/will_paginate/view_helpers/action_view.rb
+++ b/lib/will_paginate/view_helpers/action_view.rb
@@ -63,8 +63,12 @@ module WillPaginate
       # apply. Don't use the <tt>:id</tt> option; otherwise you'll finish with two
       # blocks of pagination links sharing the same ID (which is invalid HTML).
       def paginated_section(*args, &block)
-        pagination = will_paginate(*args).to_s
-        pagination + capture(&block) + pagination
+        pagination = will_paginate(*args).try(:to_s)
+        if pagination
+          pagination + capture(&block) + pagination
+        else
+          capture(&block)
+        end
       end
       
     protected

--- a/spec/view_helpers/action_view_spec.rb
+++ b/spec/view_helpers/action_view_spec.rb
@@ -166,7 +166,18 @@ describe WillPaginate::ViewHelpers::ActionView do
   end
 
   ## other helpers ##
-  
+
+  it "should not render a paginated section with a single page" do
+    @template = <<-ERB
+      <%= paginated_section collection, options do %>
+        <%= content_tag :div, '', :id => "developers" %>
+      <% end %>
+    ERB
+    paginate(:total_entries => 1)
+    assert_select 'div.pagination', 0
+    assert_select 'div#developers', 1
+  end
+
   it "should render a paginated section" do
     @template = <<-ERB
       <%= paginated_section collection, options do %>


### PR DESCRIPTION
Hi, I'm using will_paginate with Rails 3, but when using paginated_section with a collection containing only one page, it outputs escaped HTML. Investigating in code, the problem is converting 'nil' to string with 'to_s', which produces html_safe? to be false. Then, concatenating non-safe string with a safe string (capture(&block)) generates a non-safe string, which causes it to be escaped.

I'm sending a pull request with a fix that I made to deal with non-safe string.

Thanks
