### PR TITLE
Respect scoped :order option

### DIFF
--- a/lib/will_paginate/finder.rb
+++ b/lib/will_paginate/finder.rb
@@ -97,7 +97,8 @@ module WillPaginate
       # See {Faking Cursors in ActiveRecord}[http://weblog.jamisbuck.org/2007/4/6/faking-cursors-in-activerecord]
       # where Jamis Buck describes this and a more efficient way for MySQL.
       def paginated_each(options = {})
-        options = { :order => 'id', :page => 1 }.merge options
+        order = scope(:find, :order) || 'id'
+        options = { :order => order, :page => 1 }.merge options
         options[:page] = options[:page].to_i
         options[:total_entries] = 0 # skip the individual count queries
         total = 0

--- a/test/finder_test.rb
+++ b/test/finder_test.rb
@@ -284,6 +284,13 @@ class FinderTest < ActiveRecordTestCase
     assert_equal 1, entries.size
   end
 
+  def test_paginated_each_with_scoped_order
+    paginated_developers = []
+    Developer.poor.paginated_each {|d| paginated_developers << d}
+
+    assert_equal Developer.poor.all, paginated_developers, 'should use scoped :order option'
+  end
+
   ## misc ##
 
   def test_count_and_total_entries_options_are_mutually_exclusive


### PR DESCRIPTION
I hope this is pretty self-explanatory.  This patch makes it so that the paginated_each method respects any scoped :order option in ActiveRecord.
