### PR TITLE
add_limit! isn't being passed all options

### DIFF
--- a/lib/will_paginate/finder.rb
+++ b/lib/will_paginate/finder.rb
@@ -133,7 +133,7 @@ module WillPaginate
           query = sanitize_sql(sql.dup)
           original_query = query.dup
           # add limit, offset
-          add_limit! query, :offset => pager.offset, :limit => pager.per_page
+          add_limit! query, options.merge(:offset => pager.offset, :limit => pager.per_page)
           # perfom the find
           pager.replace find_by_sql(query)
           


### PR DESCRIPTION
When using paginate_by_sql the passed in options hash isn't entirely passed on to the connection adapter, only the offset and limit are. To keep things in line with other find methods that take options hashes I've merged the pagers offset/limit back into the options hash and passed it on.

This isn't really a bug in will_paginate it's more a cleaner way of getting more information down to the sql server connection adapter.
