### PR TITLE
Issue 115 validate collection create argument ranges

### DIFF
--- a/lib/will_paginate/collection.rb
+++ b/lib/will_paginate/collection.rb
@@ -47,10 +47,16 @@ module WillPaginate
     def initialize(page, per_page, total = nil)
       @current_page = page.to_i
       raise InvalidPage.new(page, @current_page) if @current_page < 1
+      raise InvalidPage.new(page, @current_page) if @current_page > 9223372036854775807
       @per_page = per_page.to_i
       raise ArgumentError, "`per_page` setting cannot be less than 1 (#{@per_page} given)" if @per_page < 1
-      
-      self.total_entries = total if total
+      raise ArgumentError, "`per_page` setting cannot be greater than BIGINT" if @per_page > 9223372036854775807
+
+      if total
+        raise ArgumentError, "`total_entries` setting cannot be less than 0 (#{total} given)" if total < 0
+        raise ArgumentError, "`total_entries` setting cannot be greater than BIGINT" if total > 9223372036854775807
+        self.total_entries = total
+      end
     end
 
     # Just like +new+, but yields the object after instantiation and returns it

--- a/test/collection_test.rb
+++ b/test/collection_test.rb
@@ -112,15 +112,27 @@ class ArrayPaginationTest < Test::Unit::TestCase
   end
 
   def test_invalid_page
-    bad_inputs = [0, -1, nil, '', 'Schnitzel']
+    bad_inputs = [0, -1, nil, '', 9223372036854775808, 'Schnitzel']
 
     bad_inputs.each do |bad|
       assert_raise(WillPaginate::InvalidPage) { create bad }
     end
   end
 
-  def test_invalid_per_page_setting
-    assert_raise(ArgumentError) { create(1, -1) }
+  def test_invalid_per_page
+    bad_inputs = [0, -1, 9223372036854775808, 'Schnitzel']
+
+    bad_inputs.each do |bad|
+      assert_raise(ArgumentError) { create(1, bad) }
+    end
+  end
+
+  def test_invalid_total_entries
+    bad_inputs = [-1, 9223372036854775808, 'Schnitzel']
+
+    bad_inputs.each do |bad|
+      assert_raise(ArgumentError) { create(1, 1, bad) }
+    end
   end
 
   def test_page_count_was_removed


### PR DESCRIPTION
Raise if arguments to Collection#create are non-numeric, negative, or greater than sql BIGINT. Prevents users from providing params which can generate invalid sql queries (ie "... LIMIT 15 OFFSET 29999999999999999999999985"). Is there a more appropriate place to validate inputs? I don't see an obvious clue as to where we should make sure to sanitize inputs to will_paginate.
