### PR TITLE
remove deprecation warning for rubygems 1.7.x

### DIFF
--- a/will_paginate.gemspec
+++ b/will_paginate.gemspec
@@ -5,18 +5,17 @@ Gem::Specification.new do |s|
   s.name    = 'will_paginate'
   s.version = WillPaginate::VERSION::STRING
   s.date    = '2010-02-05'
-  
+
   s.summary = "Adaptive pagination plugin for web frameworks and other applications"
   s.description = "The will_paginate library provides a simple, yet powerful and extensible API for pagination and rendering of page links in web application templates."
-  
+
   s.authors  = ['Mislav Marohnić']
   s.email    = 'mislav.marohnic@gmail.com'
   s.homepage = 'http://github.com/mislav/will_paginate/wikis'
-  
-  s.has_rdoc = true
+
   s.rdoc_options = ['--main', 'README.rdoc', '--charset=UTF-8']
   s.extra_rdoc_files = ['README.rdoc', 'LICENSE', 'CHANGELOG.rdoc']
-  
+
   s.files = Dir['Rakefile', '{bin,lib,test,spec}/**/*', 'README*', 'LICENSE*']
   s.files &= `git ls-files -z`.split("\0") if `type -t git 2>/dev/null || which git 2>/dev/null` && $?.success?
 end


### PR DESCRIPTION
Hello,

I have removed the has_rdoc assignment since there was no rdoc and rubygems 1.7.x complains noisily about it :)

`NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2011-10-01.
Gem::Specification#has_rdoc= called from /Users/phlipper/Projects/xxx/vendor/bundle/ruby/1.9.1/bundler/gems/will_paginate-b1a5beeec9f5/will_paginate.gemspec:16`
