### PR TITLE
Rails3.1 is now supported w/ CollectionAssociation

### DIFF
--- a/lib/will_paginate.rb
+++ b/lib/will_paginate.rb
@@ -36,7 +36,10 @@ module WillPaginate
 
       # support pagination on associations
       a = ActiveRecord::Associations
-      [ a::AssociationCollection ].tap { |classes|
+      [ a.const_defined?('CollectionAssociation') ?
+          a::CollectionAssociation :
+          a::AssociationCollection
+      ].tap { |classes|
         # detect http://dev.rubyonrails.org/changeset/9230
         unless a::HasManyThroughAssociation.superclass == a::HasManyAssociation
           classes << a::HasManyThroughAssociation


### PR DESCRIPTION
AssociationCollection was functionally renamed to CollectionAssociation.
WillPaginate can now detect the proper class name and works on both
Rails 3.1 and earlier versions.

AssociationCollections went bye-bye: https://github.com/rails/rails/blob/1644663ba7f678d178deab2bf1629dc05626f85b/activerecord/lib/active_record/associations/collection_association.rb
