### PR TITLE
Add :without_count option for paginate

### DIFF
--- a/lib/will_paginate/finder.rb
+++ b/lib/will_paginate/finder.rb
@@ -65,6 +65,7 @@ module WillPaginate
         options = args.pop
         page, per_page, total_entries = wp_parse_options(options)
         finder = (options[:finder] || 'find').to_s
+        without_count = options[:without_count]
 
         if finder == 'find'
           # an array of IDs may have been given:
@@ -74,13 +75,19 @@ module WillPaginate
         end
 
         WillPaginate::Collection.create(page, per_page, total_entries) do |pager|
-          count_options = options.except :page, :per_page, :total_entries, :finder
+          count_options = options.except :page, :per_page, :total_entries, :finder, :without_count
           find_options = count_options.except(:count).update(:offset => pager.offset, :limit => pager.per_page) 
+          find_options.update(:limit => pager.per_page + 1) if without_count
           
           args << find_options
           # @options_from_last_find = nil
-          pager.replace(send(finder, *args) { |*a| yield(*a) if block_given? })
-          
+          entries = send(finder, *args) { |*a| yield(*a) if block_given? }
+          if (without_count)
+            pager.total_entries = pager.offset + entries.size
+            entries.slice!(pager.per_page)
+          end
+          pager.replace(entries)
+
           # magic counting for user convenience:
           pager.total_entries = wp_count(count_options, args, finder) unless pager.total_entries
         end


### PR DESCRIPTION
Avoids doing a count against the database, by fetching one more item,
and adjusting total_entries to be however many were fetched.
