### PR TITLE
Allow us to override the current_page number

### DIFF
--- a/lib/will_paginate/collection.rb
+++ b/lib/will_paginate/collection.rb
@@ -39,6 +39,7 @@ module WillPaginate
   #   # WillPaginate::Collection is now available for use
   class Collection < Array
     attr_reader :current_page, :per_page, :total_entries, :total_pages
+    attr_writer :current_page
 
     # Arguments to the constructor are the current page number, per-page limit
     # and the total number of entries. The last argument is optional because it


### PR DESCRIPTION
Background: I'm using will_paginate to display results from a Google custom search. 

Reason: The 'total_entries' given by google is an estimate, so it's entirely possible for will_paginate to display more page numbers than actually exist. (i.e. '1 2 3' when there are only 2 pages of results). When we visit this last page, we get an accurate 'total_entries' number from google that I'd like to use to override the will_paginate page number. 

This works fine for me, and all tests still pass. Let me know if you'd like it done differently, or not included in will_paginate at all. (I do plan to release the google search stuff, so it would be useful to not have to patch will_paginate). 


Thanks for all the awesome work on this so far, 
Alex