### PR TITLE
"can't convert nil into Array" on Edge Rails (3.1.0.rc4)

### DIFF
--- a/lib/will_paginate/finder.rb
+++ b/lib/will_paginate/finder.rb
@@ -79,7 +79,7 @@ module WillPaginate
           
           args << find_options
           # @options_from_last_find = nil
-          pager.replace(send(finder, *args) { |*a| yield(*a) if block_given? })
+          pager.replace(block_given? ? send(finder, *args) { |*a| yield(*a) } : send(finder, *args))
           
           # magic counting for user convenience:
           pager.total_entries = wp_count(count_options, args, finder) unless pager.total_entries


### PR DESCRIPTION
Environment:
- rails 3.1.0.rc4
- ruby 1.9.2p290

This pull request corresponds to [issue #136](https://github.com/mislav/will_paginate/issues/136).

After applying this patch on your master branch, mixing with JackDanger's and dhh's branches I was basically able to use will_paginate in the above rails version ([rails3.1 branch](https://github.com/imkira/will_paginate/tree/rails3.1))

Thank you.
