### PR TITLE
Fix name of excluded parameters from count

### DIFF
--- a/lib/will_paginate/active_record.rb
+++ b/lib/will_paginate/active_record.rb
@@ -65,7 +65,7 @@ module WillPaginate
             offset_value + size
           else
             excluded = [:order, :limit, :offset]
-            excluded << :includes unless eager_loading?
+            excluded << :include unless eager_loading?
             rel = self.except(*excluded)
             # TODO: hack. decide whether to keep
             rel = rel.apply_finder_options(@wp_count_options) if defined? @wp_count_options


### PR DESCRIPTION
Regarding pull request #141, I tested the "v3.0-pre4" version, and I still got a huge query using a lot of joins, even without referencing the included tables inside the conditions.

I found out, at least in my tests, that you used a ":includes" instead of ":include". After changing it, it worked as advertised.

BTW, thank you very much for all your work on will_paginate.
