### PR TITLE
Strip ORDER BY from count

### DIFF
--- a/lib/will_paginate/active_record.rb
+++ b/lib/will_paginate/active_record.rb
@@ -165,7 +165,7 @@ module WillPaginate
           pager.replace find_by_sql(query)
 
           unless pager.total_entries
-            count_query = original_query.sub /\bORDER\s+BY\s+[\w`,\s]+$/mi, ''
+            count_query = original_query.sub /\bORDER\s+BY\s+[\w`,\s.]+$/mi, ''
             count_query = "SELECT COUNT(*) FROM (#{count_query})"
 
             unless self.connection.adapter_name =~ /^(oracle|oci$)/i

--- a/spec/finders/active_record_spec.rb
+++ b/spec/finders/active_record_spec.rb
@@ -197,12 +197,14 @@ describe WillPaginate::ActiveRecord do
 
     it "should strip the order when counting" do
       lambda {
-        sql = "select id, title, content from topics order by title"
+        sql = "select id, title, content from topics order by topics.title"
         topics = Topic.paginate_by_sql sql, :page => 1, :per_page => 2
         topics.first.should == topics(:ar)
       }.should run_queries(2)
+
+      $query_sql.find { |query| query =~ /^select count/i }.should_not include('order by topics.title')
     end
-    
+
     it "shouldn't change the original query string" do
       query = 'select * from topics where 1 = 2'
       original_query = query.dup


### PR DESCRIPTION
Hi,

I've found a bug when using paginate_by_sql that it doesn't strip the "order by" clause when it has a table name/alias specifying the columns. There is an open issue #120 about that.
Does anyone sees a problem on adding a dot in regex for strip "order by" clause?
