### PR TITLE
Fix ActiveRecord empty? method on grouped results

### DIFF
--- a/lib/will_paginate/active_record.rb
+++ b/lib/will_paginate/active_record.rb
@@ -80,8 +80,9 @@ module WillPaginate
 
       # overloaded to be pagination-aware
       def empty?
+        relation_count = count.respond_to?(:size) and !count.is_a?(Integer) ? count.size : count
         if !loaded? and offset_value
-          count <= offset_value
+          relation_count <= offset_value
         else
           super
         end


### PR DESCRIPTION
This is a prouposal fix based on 87f827
