### PR TITLE
Optimize sql limit for half-full pages

### DIFF
--- a/spec/finders/active_record_spec.rb
+++ b/spec/finders/active_record_spec.rb
@@ -286,6 +286,21 @@ describe WillPaginate::ActiveRecord do
     result.total_entries.should == 4
   end
   
+  describe "when the number of items on the current page is known" do
+    it "should use the regular limit where there are enough items to fill the page" do
+      Topic.expects(:limit).with(10).returns(Topic)
+      Topic.paginate(:page=>1, :per_page=>10, :total_entries=>13)
+    end
+    it "should reduce limit if there's not enough items to fill the page" do
+      Topic.expects(:limit).with(3).returns(Topic)
+      Topic.paginate(:page=>2, :per_page=>10, :total_entries=>13)
+    end
+    it "should set limit=0 when we go past the last page" do
+      Topic.expects(:limit).with(0).returns(Topic)
+      Topic.paginate(:page=>3, :per_page=>10, :total_entries=>13)
+    end
+  end
+
   describe "associations" do
     it "should paginate with include" do
       project = projects(:active_record)


### PR DESCRIPTION
Hi, I have a possible optimization up for discussion.  If we have per_page=10, but happen to know via total_entries that there's only 1 item on the current page, it can be significantly faster if we tell the database to only find 1 result, rather than looking for the other 9 that don't exist.

This patch only fixes the limit for Model.paginate cases for now.  I haven't quite wrapped my head around the RelationMethods module and whether it's possible to apply this optimization there... am I right in thinking it's not possible to set total_entries when using the Model.page(2) approach?

Did that make sense?  Any thoughts?

-Jonathan
