### PR TITLE
Added the possibility to override I18n lookup/default page_gap with an option to the will_paginate view helper

### DIFF
--- a/lib/will_paginate/view_helpers.rb
+++ b/lib/will_paginate/view_helpers.rb
@@ -23,6 +23,7 @@ module WillPaginate
       :class          => 'pagination',
       :previous_label => nil,
       :next_label     => nil,
+      :page_gap       => nil,
       :inner_window   => 4, # links around the current page
       :outer_window   => 1, # links around beginning and end
       :link_separator => ' ', # single space is friendly to spiders and non-graphic browsers

--- a/lib/will_paginate/view_helpers/link_renderer.rb
+++ b/lib/will_paginate/view_helpers/link_renderer.rb
@@ -49,7 +49,7 @@ module WillPaginate
       end
       
       def gap
-        text = @template.will_paginate_translate(:page_gap) { '&hellip;' }
+        text = @options[:page_gap] || @template.will_paginate_translate(:page_gap) { '&hellip;' }
         %(<span class="gap">#{text}</span>)
       end
       


### PR DESCRIPTION
I've added the possibility to override the page_gap in the same way as it is possible to override the next_label and previous_label by sending it in the options hash to the will_paginate view helper.
