### PR TITLE
passing scope to url_for

### DIFF
--- a/lib/will_paginate/view_helpers/action_view.rb
+++ b/lib/will_paginate/view_helpers/action_view.rb
@@ -113,9 +113,12 @@ module WillPaginate
         add_current_page_param(url_params, page)
 
         if url_params[:scope]
-          return url_params[:scope].url_for(url_params)
+          scope = url_params[:scope]
+          url_params.delete(:scope)
+          url_params.delete(:controller)
+          scope.url_for(url_params)
         else
-          return @template.url_for(url_params)
+          @template.url_for(url_params)
         end
       end
 

--- a/lib/will_paginate/view_helpers/action_view.rb
+++ b/lib/will_paginate/view_helpers/action_view.rb
@@ -112,7 +112,11 @@ module WillPaginate
         url_params = @base_url_params.dup
         add_current_page_param(url_params, page)
 
-        @template.url_for(url_params)
+        if url_params[:scope]
+          return url_params[:scope].url_for(url_params)
+        else
+          return @template.url_for(url_params)
+        end
       end
 
       def merge_get_params(url_params)

--- a/will_paginate.gemspec
+++ b/will_paginate.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary = "Pagination plugin for web frameworks and other apps"
   s.description = "will_paginate provides a simple API for performing paginated queries with Active Record, DataMapper and Sequel, and includes helpers for rendering pagination links in Rails, Sinatra and Merb web apps."
   
-  s.authors  = ['Mislav Marohnić']
+  s.authors  = ['Mislav Marohnic']
   s.email    = 'mislav.marohnic@gmail.com'
   s.homepage = 'https://github.com/mislav/will_paginate/wiki'
   


### PR DESCRIPTION
this is a fix to allow for scope to be passed in to url_for, this is necessary for mountable engine support in rails 3.1. let me know if you have any questions
thanks,
adam
