### PR TITLE
Fix bug where page_entries_info does render correctly with a group by clause

### DIFF
--- a/lib/will_paginate/view_helpers.rb
+++ b/lib/will_paginate/view_helpers.rb
@@ -138,6 +138,8 @@ module WillPaginate
         keys = [:"#{model_key}.#{i18n_key}", i18n_key]
         
         count = collection.size
+        
+        # If a group clause was used, count is returned as hash of :group => :count
         count = count.length if count.is_a? Hash
         will_paginate_translate keys, :count => count, :model => model_name do |_, opts|
           case opts[:count]


### PR DESCRIPTION
When using ActiveRecordModel.paginate(:group => "my_group_field", :page => 1), the page_entries_info helper renders incorrectly: Displaying {1 => 2} models. This is because collection.size returns the size as a hash. The length of the hash is the value we want to show in the page_entries_info.
