### PR TITLE
Error during Rails 3.2 fail-safe response

### DIFF
--- a/lib/will_paginate/railtie.rb
+++ b/lib/will_paginate/railtie.rb
@@ -41,13 +41,11 @@ module WillPaginate
       extend ActiveSupport::Concern
       included { alias_method_chain :status_code, :paginate }
       private
-      def status_code_with_paginate(exception = self.exception)
-        if exception.is_a?(WillPaginate::InvalidPage) or
-            (exception.respond_to?(:original_exception) &&
-              exception.original_exception.is_a?(WillPaginate::InvalidPage))
+      def status_code_with_paginate
+        if @exception.is_a?(WillPaginate::InvalidPage)
           Rack::Utils.status_code(:not_found)
         else
-          status_code_without_paginate(exception)
+          status_code_without_paginate
         end
       end
     end


### PR DESCRIPTION
Did Rails 3.2 change since your change?

It looks like there's a bug again - status_code no longer takes any params.

Here's my fix - not sure if it's correct...

//Lars
