### PR TITLE
add extra_attributes option that adds extra attributes to links.

### DIFF
--- a/lib/will_paginate/view_helpers/link_renderer.rb
+++ b/lib/will_paginate/view_helpers/link_renderer.rb
@@ -93,6 +93,7 @@ module WillPaginate
           target = url(target)
         end
         attributes[:href] = target
+        attributes = @options[:extra_attributes].merge(attributes) if @options[:extra_attributes]
         tag(:a, text, attributes)
       end
       


### PR DESCRIPTION
This is a generalization of of issue #133 / issue #100, which adds the data-remote attribute. Not all ajax frameworks work the same was as rails ujs.
