### PR TITLE
add :ignore_params option to the action_view LinkRenderer

### DIFF
--- a/lib/will_paginate/view_helpers/action_view.rb
+++ b/lib/will_paginate/view_helpers/action_view.rb
@@ -117,7 +117,7 @@ module WillPaginate
 
       def merge_get_params(url_params)
         if @template.respond_to? :request and @template.request and @template.request.get?
-          symbolized_update(url_params, @template.params)
+          symbolized_update(url_params, @template.params.except(*@options[:ignore_params]))
         end
         url_params
       end


### PR DESCRIPTION
the will_paginate view helper copies query parameters from the request
onto the page links.   This is virtually always the right thing to do
for standard requests, but when the links are inside an HTML fragment
generated via AJAX, those links often contain extra params that
shouldn't be mirrored into the link.
