### PR TITLE
Carry over pagination info on map

### DIFF
--- a/lib/will_paginate/collection.rb
+++ b/lib/will_paginate/collection.rb
@@ -133,9 +133,19 @@ module WillPaginate
       result
     end
 
+    # We want to return paginated collections when mapped. Unfortunately
+    # when arrays are copied in C code for slices or other operations,
+    # they are initialized using the array initializer, not ours. This
+    # means that current page is lost and creating a new array is impossible.
+    # we treat copied arrays as non-paginated collections and just delegate to super.
+
     def map(&block)
-      self.class.create(current_page, per_page, total_entries) do |pager|
-        pager.replace(super(&block))
+      if current_page.nil?
+        super(&block)
+      else
+        self.class.create(current_page, per_page, total_entries) do |pager|
+          pager.replace(super(&block))
+        end
       end
     end
   end

--- a/lib/will_paginate/collection.rb
+++ b/lib/will_paginate/collection.rb
@@ -132,5 +132,11 @@ module WillPaginate
 
       result
     end
+
+    def map(&block)
+      self.class.create(current_page, per_page, total_entries) do |pager|
+        pager.replace(super(&block))
+      end
+    end
   end
 end

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -123,6 +123,21 @@ describe WillPaginate::Collection do
     collection.per_page.should == 30
   end
 
+  describe "map" do
+    it "should correctly map the values" do
+      collection = create {|p| p.replace([1,2,3])}
+      collection.map {|v| v*2}.should == [2,4,6]
+    end 
+
+    it "should maintain pager methods" do
+      collection = create(2,5,100) {|p| p.replace([1,2,3])}
+      mapped = collection.map {|v| v*2 }
+      mapped.current_page.should == 2
+      mapped.per_page.should == 5
+      mapped.total_entries.should == 100
+    end
+  end
+
   private
   
     def create(page = 2, limit = 5, total = nil, &block)

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -136,6 +136,12 @@ describe WillPaginate::Collection do
       mapped.per_page.should == 5
       mapped.total_entries.should == 100
     end
+
+    it "should not raise an error when the array is copied by C code" do
+      collection = create(2,5,100) {|p| p.replace([1,2,3])}
+      copied = collection[0..1]
+      copied.map {|a| a*2}
+    end
   end
 
   private


### PR DESCRIPTION
This change will make calls to map on a paginated collection return paginated info. This can be really handy if you return a paginated list of OrderItems and want to map that to a list of Products in your controller. Before, you had to map and create a new collection. This makes it just work.
