### PR TITLE
Using the #total_pages method of LinkRendererBase also in LinkRenderer

### DIFF
--- a/lib/will_paginate/view_helpers/link_renderer.rb
+++ b/lib/will_paginate/view_helpers/link_renderer.rb
@@ -59,7 +59,7 @@ module WillPaginate
       end
       
       def next_page
-        num = @collection.current_page < @collection.total_pages && @collection.current_page + 1
+        num = @collection.current_page < total_pages && @collection.current_page + 1
         previous_or_next_page(num, @options[:next_label], 'next_page')
       end
       


### PR DESCRIPTION
Helps to easily change the behavior of the view helper concerning the total pages to be shown.
