### PR TITLE
Set :total_entries < 0 for uncounted paging.

### DIFF
--- a/lib/will_paginate/collection.rb
+++ b/lib/will_paginate/collection.rb
@@ -13,7 +13,9 @@ module WillPaginate
   # This module provides few of these methods.
   module CollectionMethods
     def total_pages
-      total_entries.zero? ? 1 : (total_entries / per_page.to_f).ceil
+      return  1 if total_entries.zero?
+      return -1 if total_entries < 0
+      (total_entries / per_page.to_f).ceil
     end
 
     # current_page - 1 or nil if there is no previous page
@@ -23,7 +25,7 @@ module WillPaginate
 
     # current_page + 1 or nil if there is no next page
     def next_page
-      current_page < total_pages ? (current_page + 1) : nil
+      ((current_page < total_pages) || (total_pages < 0)) ? (current_page + 1) : nil
     end
 
     # Helper method that is true when someone tries to fetch a page with a

--- a/lib/will_paginate/view_helpers.rb
+++ b/lib/will_paginate/view_helpers.rb
@@ -71,7 +71,8 @@ module WillPaginate
     #
     def will_paginate(collection, options = {})
       # early exit if there is nothing to render
-      return nil unless collection.total_pages > 1
+      return nil if collection.total_pages == 0 ||
+                    (collection.current_page == 1 && collection.length < collection.per_page)
 
       options = WillPaginate::ViewHelpers.pagination_options.merge(options)
 

--- a/lib/will_paginate/view_helpers.rb
+++ b/lib/will_paginate/view_helpers.rb
@@ -76,6 +76,8 @@ module WillPaginate
 
       options = WillPaginate::ViewHelpers.pagination_options.merge(options)
 
+      options[:page_links] = false if collection.total_pages < 0
+
       options[:previous_label] ||= will_paginate_translate(:previous_label) { '&#8592; Previous' }
       options[:next_label]     ||= will_paginate_translate(:next_label) { 'Next &#8594;' }
 

--- a/lib/will_paginate/view_helpers/link_renderer.rb
+++ b/lib/will_paginate/view_helpers/link_renderer.rb
@@ -59,7 +59,9 @@ module WillPaginate
       end
       
       def next_page
-        num = @collection.current_page < @collection.total_pages && @collection.current_page + 1
+        num = ((@collection.current_page < @collection.total_pages) ||
+               (@collection.total_pages < 0 && @collection.length >= @collection.per_page)) &&
+              @collection.current_page + 1
         previous_or_next_page(num, @options[:next_label], 'next_page')
       end
       


### PR DESCRIPTION
Pagination on really large data sets is very slow because of the count(*) requirement to find number of pages.  This can be fixed by setting :total_entries to the correct size.  However, if you do not know what that is supposed to be you are stuck approximating.

This patch makes it possible to have just previous/next links whenever there are pages behind/ahead by setting :total_entries to -1.  I figure -1 is a pretty good value for "I have no idea how many there are, but I DON'T want you counting either!"

There is one caveat with this method.  The last page may be blank if the next to last page has the last item and is full.  
