### PR TITLE
fix for "Error during failsafe response: private method `status_code' ca...

### DIFF
--- a/lib/will_paginate/railtie.rb
+++ b/lib/will_paginate/railtie.rb
@@ -40,7 +40,6 @@ module WillPaginate
     module ShowExceptionsPatch
       extend ActiveSupport::Concern
       included { alias_method_chain :status_code, :paginate }
-      private
       def status_code_with_paginate(exception = @exception)
         if exception.is_a?(WillPaginate::InvalidPage) or
             (exception.respond_to?(:original_exception) &&


### PR DESCRIPTION
fix for "Error during failsafe response: private method `status_code' called for #ActionDispatch::ExceptionWrapper:0x..."

The above error is dumped to the log whenever a backtrace is dumped to the log for an app that uses will_paginate along with a Rails 3.2 and Hobo 1.4.

Hobo 1.4 never uses ExceptionWrapper or status_code; I'm not sure why it brings out this behaviour in Rails.  Regardless, status_code is public in Rails, so bringing it private is probably not a good idea.
