### PR TITLE
Don't require dm-aggregates in will_paginate/data_mapper

### DIFF
--- a/lib/will_paginate/data_mapper.rb
+++ b/lib/will_paginate/data_mapper.rb
@@ -1,5 +1,4 @@
 require 'dm-core'
-require 'dm-aggregates'
 require 'will_paginate/per_page'
 require 'will_paginate/page_number'
 require 'will_paginate/collection'

--- a/spec/finders/data_mapper_test_connector.rb
+++ b/spec/finders/data_mapper_test_connector.rb
@@ -1,5 +1,6 @@
 require 'sqlite3'
 require 'dm-core'
+require 'dm-aggregates'
 require 'dm-core/support/logger'
 require 'dm-migrations'
 


### PR DESCRIPTION
Not all DM adapters implement the necessary interface for the dm-aggregates plugin, but may instead implement a #count method by other means. Since will_paginate really only needs a working #count method on the DM collection to function, let DM users require dm-aggregates in their own code if they want it.

I've also added a require of dm-aggregates to the DM test connector to maintain the present behavior of that test.
