### PR TITLE
Removed duplicate doc entry for page_links

### DIFF
--- a/lib/will_paginate/view_helpers.rb
+++ b/lib/will_paginate/view_helpers.rb
@@ -47,7 +47,6 @@ module WillPaginate
     # * <tt>:class</tt> -- CSS class name for the generated DIV (default: "pagination")
     # * <tt>:previous_label</tt> -- default: "« Previous"
     # * <tt>:next_label</tt> -- default: "Next »"
-    # * <tt>:page_links</tt> -- when false, only previous/next links are rendered (default: true)
     # * <tt>:inner_window</tt> -- how many links are shown around the current page (default: 4)
     # * <tt>:outer_window</tt> -- how many links are around the first and the last page (default: 1)
     # * <tt>:link_separator</tt> -- string separator for page HTML elements (default: single space)


### PR DESCRIPTION
Hi,

There was some duplicate content in the documentation so I removed one of the duplicate (I chose which one to keep based on the params order of the method).

cheers
