### PR TITLE
render page links for zero or one page

### DIFF
--- a/lib/will_paginate/view_helpers/link_renderer.rb
+++ b/lib/will_paginate/view_helpers/link_renderer.rb
@@ -49,7 +49,7 @@ module WillPaginate
       end
       
       def gap
-        text = (@options[:previous_label].nil?) ? (@template.will_paginate_translate(:page_gap) { '&hellip;' }) :@options[:previous_label]
+        text = @template.will_paginate_translate(:page_gap) { '&hellip;' }
         %(<span class="gap">#{text}</span>)
       end
       

--- a/spec/view_helpers/base_spec.rb
+++ b/spec/view_helpers/base_spec.rb
@@ -20,7 +20,7 @@ describe WillPaginate::ViewHelpers do
   
   describe "will_paginate" do
 
-    def builder_renderer collection
+    def build_renderer collection
       renderer = mock 'Renderer'
       renderer.expects(:prepare).with(collection, instance_of(Hash), self)
       renderer.expects(:to_html).returns('<PAGES>')
@@ -29,7 +29,7 @@ describe WillPaginate::ViewHelpers do
 
     it "should render" do
       collection = WillPaginate::Collection.new(1, 2, 4)
-      renderer   = builder_renderer collection
+      renderer   = build_renderer collection
       
       will_paginate(collection, :renderer => renderer).should == '<PAGES>'
     end
@@ -41,7 +41,7 @@ describe WillPaginate::ViewHelpers do
 
     it "should render for single-page collections with param always_render" do
       collection = WillPaginate::Collection.new(1, 1, 1)
-      renderer   = builder_renderer collection
+      renderer   = build_renderer collection
 
       will_paginate(collection, :renderer => renderer, :always_render => true).should == '<PAGES>'
     end


### PR DESCRIPTION
This is a demand in one of my projects.
The client says the pagination info should always has the same behavior, it should not disappear at a time and appear at another time.
So, I add a param 'always_render' for always showing the pagination info.
