### PR TITLE
param duplication in sinatra view helper with optional params

### DIFF
--- a/lib/will_paginate/view_helpers/sinatra.rb
+++ b/lib/will_paginate/view_helpers/sinatra.rb
@@ -19,7 +19,7 @@ module WillPaginate
       def url(page)
         str = File.join(request.script_name.to_s, request.path_info)
         params = request.GET.merge(param_name.to_s => page.to_s)
-        params.update @options[:params] if @options[:params]
+        params.update stringify_param_keys(@options[:params]) if @options[:params]
         str << '?' << build_query(params)
       end
 
@@ -34,6 +34,10 @@ module WillPaginate
 
     def self.registered(app)
       app.helpers Helpers
+    end
+
+    def stringify_param_keys(params)
+      Hash[params.map { |k,v| [ k.to_s, v ] }]
     end
 
     ::Sinatra.register self


### PR DESCRIPTION
This fixes the bug with duplicate params being generated if the optional param keys are symbols.

https://github.com/mislav/will_paginate/issues/286
