### PR TITLE
Remove ć from gemspec to install in JRuby

### DIFF
--- a/will_paginate.gemspec
+++ b/will_paginate.gemspec
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require 'config'
+require 'rbconfig'
 require File.expand_path('../lib/will_paginate/version', __FILE__)
 
 Gem::Specification.new do |s|


### PR DESCRIPTION
JRuby 1.7.3 gives this error when installing: ERROR:  While executing gem ... (Psych::SyntaxError)
    (<unknown>): 'reader' unacceptable character '' (0x87) special characters are not allowed
in "'reader'", position 164 at line 0 column 0

Changed to 'c', built gem and installed just fine.
