### PR TITLE
Accept arguments for `#count`

### DIFF
--- a/lib/will_paginate/active_record.rb
+++ b/lib/will_paginate/active_record.rb
@@ -78,14 +78,14 @@ module WillPaginate
         end
       end
 
-      def count
+      def count(*args)
         if limit_value
           excluded = [:order, :limit, :offset, :reorder]
           excluded << :includes unless eager_loading?
           rel = self.except(*excluded)
           # TODO: hack. decide whether to keep
           rel = rel.apply_finder_options(@wp_count_options) if defined? @wp_count_options
-          rel.count
+          rel.count(*args)
         else
           super
         end

--- a/spec/finders/active_record_spec.rb
+++ b/spec/finders/active_record_spec.rb
@@ -205,6 +205,11 @@ describe WillPaginate::ActiveRecord do
       $query_sql.last.should_not =~ /\ORDER\b/
     end
 
+    it "accepts arguments for #count" do
+      Project.page(1).count(distinct: true)
+      $query_sql.last.should =~ /COUNT\(DISTINCT/
+    end
+
     it "should not have zero total_pages when the result set is empty" do
       Developer.where("1 = 2").page(1).total_pages.should == 1
     end


### PR DESCRIPTION
Sometimes it is needed to call `relation.count(distinct: true)`. I am not sure what is the best way to test it within will_paginate's testing conventions. Can you guys give me some advice?

Thanks in advance.
