### PR TITLE
 	Require paginate-extension for Array

### DIFF
--- a/lib/will_paginate.rb
+++ b/lib/will_paginate.rb
@@ -2,6 +2,8 @@
 module WillPaginate
 end
 
+require 'will_paginate/array'
+
 if defined?(Rails::Railtie)
   require 'will_paginate/railtie'
 elsif defined?(Rails::Initializer)


### PR DESCRIPTION
When the gem is loaded, then the paginate-method for the Array-class is not required.

This patch will fix it. Any comments? Cheers! Robin.
