### PR TITLE
Added deprecation warning to Pagination#paginate for Rails 4 #apply_finder_options deprecation in ActiveRecord

### DIFF
--- a/lib/will_paginate/active_record.rb
+++ b/lib/will_paginate/active_record.rb
@@ -141,7 +141,10 @@ module WillPaginate
     end
 
     module Pagination
+      # <b>DEPRECATED:</b> Please use <tt>page</tt> instead.
       def paginate(options)
+        warn "DEPRECATION WARNING: Pagination#paginate is deprecated. Please use Pagination#page instead. Called from: " + Kernel.caller.first
+
         options  = options.dup
         pagenum  = options.fetch(:page) { raise ArgumentError, ":page parameter required" }
         per_page = options.delete(:per_page) || self.per_page


### PR DESCRIPTION

This is related to https://github.com/mislav/will_paginate/issues/322.

Naturally many specs now show the deprecation warning because of this.