### PR TITLE
Use value#to_i instead of Kernel#Integer() to coerce page number into integer.

### DIFF
--- a/lib/will_paginate/page_number.rb
+++ b/lib/will_paginate/page_number.rb
@@ -13,7 +13,7 @@ module WillPaginate
     extend Forwardable
 
     def initialize(value, name)
-      value = Integer(value)
+      value = value.to_i
       if 'offset' == name ? (value < 0 or value > BIGINT) : value < 1
         raise RangeError, "invalid #{name}: #{value.inspect}"
       end


### PR DESCRIPTION
Integer() is pickier than #to_i. `Integer("5/")` throws an exception, while `"5/".to_i` returns 5.
