### PR TITLE
AR: Do not spawn additional queries when rendering page_entries_info.

### DIFF
--- a/lib/will_paginate/view_helpers.rb
+++ b/lib/will_paginate/view_helpers.rb
@@ -104,7 +104,13 @@ module WillPaginate
     # The default output contains HTML. Use ":html => false" for plain text.
     def page_entries_info(collection, options = {})
       model = options[:model]
-      model = collection.first.class unless model or collection.empty?
+      unless model
+        if collection.respond_to? :klass
+          model = collection.klass
+        elsif not collection.empty?
+          model = collection.first.class
+        end
+      end
       model ||= 'entry'
       model_key = if model.respond_to? :model_name
                     model.model_name.i18n_key  # ActiveModel::Naming


### PR DESCRIPTION
`collection.first.class` will spawn a LIMIT 1 query, while `collection.empty?`
will spawn a COUNT query. The latter is not a problem since a COUNT query is
needed anyway, so redundant ones will retrieve from cache. The former, however,
can add unnecessary load to the database.

As far as I can tell, ActiveRecord::Relation has a `klass` attribute since the
beginning, so it should be fine. The attribute is also aliased as `model` since
https://github.com/rails/rails/pull/6606, though this change is only available
in Rails 4.x.
