### PR TITLE
Fixes issue with page parameter being a Fixnum

### DIFF
--- a/lib/will_paginate/view_helpers/action_view.rb
+++ b/lib/will_paginate/view_helpers/action_view.rb
@@ -129,7 +129,7 @@ module WillPaginate
 
       def add_current_page_param(url_params, page)
         unless param_name.index(/[^\w-]/)
-          url_params[param_name.to_sym] = page
+          url_params[param_name.to_sym] = page.to_s
         else
           page_param = parse_query_parameters("#{param_name}=#{page}")
           symbolized_update(url_params, page_param)


### PR DESCRIPTION
Fixes Issue #364

The page number should always be a string when adding the current page param to the `url_params` hash since later it does a `CGI::escape` on the parameter.

```ruby
    129: def add_current_page_param(url_params, page)
 => 130:   binding.pry
    131:
    132:   unless param_name.index(/[^\w-]/)
    133:     url_params[param_name.to_sym] = page
    134:   else
    135:     page_param = parse_query_parameters("#{param_name}=#{page}")
    136:     symbolized_update(url_params, page_param)
    137:   end
    138: end
```

The `else` statement turns the page parameter into a string, so the `unless` block should as well.

```ruby
[2] pry(#<WillPaginate::ActionView::LinkRenderer>)> page_param = parse_query_parameters("#{param_name}=#{page}")
=> {"page"=>"1"}
[3] pry(#<WillPaginate::ActionView::LinkRenderer>)> symbolized_update(url_params, page_param)
=> {"page"=>"1"}
[4] pry(#<WillPaginate::ActionView::LinkRenderer>)> url_params
=> {:from=>"2014-02-03", :page=>"1", :action=>"index", :controller=>"usage"}

# This us what's causing the error.
[5] pry(#<WillPaginate::ActionView::LinkRenderer>)> url_params[param_name.to_sym] = page
=> {:from=>"2014-02-03", :page=>1, :action=>"index", :controller=>"usage"}

# This is how it should be
[6] pry(#<WillPaginate::ActionView::LinkRenderer>)> url_params[param_name.to_sym] = page.to_s
=> {:from=>"2014-02-03", :page=>"1", :action=>"index", :controller=>"usage"}
```

All specs pass:
`bundle exec rspec ./specs` => `146 examples, 0 failures`