### PR TITLE
don't perform two separate SELECT queries instead of just one in some circumstances on Ruby 1.9

### DIFF
--- a/lib/will_paginate/finder.rb
+++ b/lib/will_paginate/finder.rb
@@ -164,6 +164,10 @@ module WillPaginate
       
       def method_missing_with_paginate(method, *args) #:nodoc:
         # did somebody tried to paginate? if not, let them be
+        if method == :respond_to_missing?
+          return false
+        end
+
         unless method.to_s.index('paginate') == 0
           if block_given?
             return method_missing_without_paginate(method, *args) { |*a| yield(*a) }


### PR DESCRIPTION
will_paginate for Rails 2.3 has been causing huge memory leaks in our production environment after upgrading to Ruby 1.9. The code was all the same and it works OK on 1.8 and doesn't on 1.9. This is because will_paginate performs one extra query on Ruby 1.9.

Code: `Zone.by_domain('example.com').first.hosts.not_deleted.find_all_by_hostname 'hcbrasil'`

1.8: 
```
Zone Load (1.5ms)   SELECT * FROM "zones" WHERE ("zones"."domain" = 'example.com') LIMIT 1
Host Load (1.0ms)   SELECT * FROM "hosts" WHERE ("hosts"."hostname" = 'hcbrasil') AND (("hosts"."state" IN ('active','inactive')) AND ("hosts".zone_id = 123))
```

1.9:
```
Zone Load (0.6ms)   SELECT * FROM "zones" WHERE ("zones"."domain" = 'example.com') LIMIT 1 # Zone.by_domain('example.com')
Host Load (359.3ms)   SELECT * FROM "hosts" WHERE ("hosts".zone_id = 123) AND ("hosts"."state" IN ('active','inactive')) # hosts.not_deleted
Host Load (0.4ms)   SELECT * FROM "hosts" WHERE ("hosts"."hostname" = 'hcbrasil') AND (("hosts"."state" IN ('active','inactive')) AND ("hosts".zone_id = 123)) # hosts.not_deleted.find_all_by_hostname SEPARATELY o_O
```

This is all because will_paginate doesn't know of `respond_to_missing?` method that was introduced in Ruby 1.9.

From activerecord/lib/active_record/associations/association_collection.rb:
```
      def proxy_respond_to?(method, include_private = false)
        super || @reflection.klass.respond_to?(method, include_private)
      end
```

`super` will call `respond_to`. In Ruby 1.9 `respond_to` will also call `respond_to_missing?` which will be incorrectly caught by will_paginate and considered a query! 

Then will_paginate requests `load_target` in association_collection and we have 150000 ActiveRecord objects instantiated. Memory and time consuming.

This patch fixes it. Unit tests pass so I didn't break anything. Would be great if you could release a new version, 2.3.17.