### PR TITLE
Active record count fix for ruby 4.1.x

### DIFF
--- a/lib/will_paginate/active_record.rb
+++ b/lib/will_paginate/active_record.rb
@@ -87,7 +87,7 @@ module WillPaginate
           rel = rel.apply_finder_options(@wp_count_options) if defined? @wp_count_options
           rel.count
         else
-          super
+          super(:all)
         end
       end
 


### PR DESCRIPTION
Moved from deprecated count method for rails 4.1. Previous code causes an sql syntax error when using "AS" for assigning temporary column name in a select statement.

'''
Venue.select('venues.*, name as venue_name').paginate(page: 1, per_page: 20)
"'

Related issues:
http://stackoverflow.com/questions/23523356/rails-4-1-1-w-pg-search-pgsyntaxerror-error-syntax-error-at-or-near-as
https://github.com/rails/rails/issues/13648
