### PR TITLE
Failing specs for total_entries in Rails 4.1

### DIFF
--- a/spec/finders/active_record_spec.rb
+++ b/spec/finders/active_record_spec.rb
@@ -205,6 +205,10 @@ describe WillPaginate::ActiveRecord do
       Developer.select("COALESCE(salary,0.0) AS salary").page(1).total_entries.should == 11
     end
 
+    it "should count with select" do
+      Developer.select("id, salary").page(1).total_entries.should == 11
+    end
+
     it "removes :reorder for count with group" do
       Project.group(:id).reorder(:id).page(1).total_entries
       $query_sql.last.should_not =~ /\ORDER\b/


### PR DESCRIPTION
This is the case where `count(:all)` should be the solution.
https://github.com/mislav/will_paginate/blob/master/lib/will_paginate/active_record.rb#L79

But that fails another test:

> WillPaginate::ActiveRecord should not ignore :select parameter when it says DISTINCT
> https://github.com/mislav/will_paginate/blob/master/spec/finders/active_record_spec.rb#L214

Using `count(:all)` doesn't work as desired if we actually want to keep the distinct `select('DISTINCT salary')`. And it appears not to work alongside  `select('salary').distinct` either.

I'm not sure what the solution is.
