### PR TITLE
Rename `select_for_count` method. Fixes #400.

### DIFF
--- a/lib/will_paginate/active_record.rb
+++ b/lib/will_paginate/active_record.rb
@@ -91,7 +91,7 @@ module WillPaginate
           # TODO: hack. decide whether to keep
           rel = rel.apply_finder_options(@wp_count_options) if defined? @wp_count_options
           
-          column_name = (select_for_count(rel) || :all)
+          column_name = (select_value_for_count(rel) || :all)
           rel.count(column_name)
         else
           super(*args)
@@ -146,7 +146,7 @@ module WillPaginate
         other
       end
       
-      def select_for_count(rel)
+      def select_value_for_count(rel)
         if rel.select_values.present?
           select = rel.select_values.join(", ")
           select if select !~ /[,*]/


### PR DESCRIPTION
This commit renames `select_for_count` method to `select_value_for_count`. First name caused conflict with method in rails and caused error reported in #400.
