### PR TITLE
Resolved issue in count method

### DIFF
--- a/lib/will_paginate/active_record.rb
+++ b/lib/will_paginate/active_record.rb
@@ -92,10 +92,11 @@ module WillPaginate
           rel = rel.apply_finder_options(@wp_count_options) if defined? @wp_count_options
           
           column_name = (select_for_count(rel) || :all)
-          if rel.count(column_name).is_a? Hash
+          data_length = rel.count(column_name)
+          if data_length.is_a? Hash
             rel.length
           else
-            rel.count(column_name)
+            data_length
           end
         else
           super(*args)

--- a/lib/will_paginate/active_record.rb
+++ b/lib/will_paginate/active_record.rb
@@ -92,7 +92,11 @@ module WillPaginate
           rel = rel.apply_finder_options(@wp_count_options) if defined? @wp_count_options
           
           column_name = (select_for_count(rel) || :all)
-          rel.count(column_name)
+          if rel.count(column_name).is_a? Hash
+            rel.size
+          else
+            rel.count(column_name)
+          end
         else
           super(*args)
         end

--- a/lib/will_paginate/active_record.rb
+++ b/lib/will_paginate/active_record.rb
@@ -93,7 +93,7 @@ module WillPaginate
           
           column_name = (select_for_count(rel) || :all)
           if rel.count(column_name).is_a? Hash
-            rel.size
+            rel.length
           else
             rel.count(column_name)
           end


### PR DESCRIPTION
Whenever we do total_entries on a collection of active record objects on a query that contains GROUP BY, it converts collection into hash and return its count whereas it should return count of the active relation and not the hash.
