### PR TITLE
Child relationship per_page fails with Strings

### DIFF
--- a/lib/will_paginate/active_record.rb
+++ b/lib/will_paginate/active_record.rb
@@ -30,7 +30,7 @@ module WillPaginate
 
       def per_page(value = nil)
         if value.nil? then limit_value
-        else limit(value)
+        else limit(value.to_i)
         end
       end
 

--- a/spec/finders/active_record_spec.rb
+++ b/spec/finders/active_record_spec.rb
@@ -66,7 +66,7 @@ describe WillPaginate::ActiveRecord do
     end
     
     it "casts values to int in relations" do
-      rel = Topic.first.replies.page("1").per_page("3")
+      rel = Topic.find(1).replies.page("1").per_page("3")
       rel.current_page.should == 1
       rel.per_page.should == 3
       lambda {

--- a/spec/finders/active_record_spec.rb
+++ b/spec/finders/active_record_spec.rb
@@ -64,6 +64,15 @@ describe WillPaginate::ActiveRecord do
         rel.total_entries.should == 1
       }.should run_queries(1)
     end
+    
+    it "casts values to int in relations" do
+      rel = Topic.first.replies.page("1").per_page("3")
+      rel.current_page.should == 1
+      rel.per_page.should == 3
+      lambda {
+        rel.total_entries.should == 2
+      }.should run_queries(1)
+    end
 
     it "supports the page() method" do
       rel = Developer.page('1').order('id')


### PR DESCRIPTION
I ran into an issue when setting a child relationship's per_page as a String value. I was getting an error with limit_value in `if loaded? and size < limit_value and (current_page == 1 or size > 0)` in `ActiveRecord::RelationMethods::total_entries`.

Let me know if you need anything else.