### PR TITLE
Fix oracle sql for pagination_by_sql

### DIFF
--- a/lib/will_paginate/active_record.rb
+++ b/lib/will_paginate/active_record.rb
@@ -10,10 +10,10 @@ end
 
 module WillPaginate
   # = Paginating finders for ActiveRecord models
-  # 
+  #
   # WillPaginate adds +paginate+, +per_page+ and other methods to
   # ActiveRecord::Base class methods and associations.
-  # 
+  #
   # In short, paginating finders are equivalent to ActiveRecord finders; the
   # only difference is that we start with "paginate" instead of "find" and
   # that <tt>:page</tt> is required parameter:
@@ -90,7 +90,7 @@ module WillPaginate
           rel = self.except(*excluded)
           # TODO: hack. decide whether to keep
           rel = rel.apply_finder_options(@wp_count_options) if defined? @wp_count_options
-          
+
           column_name = (select_for_count(rel) || :all)
           rel.count(column_name)
         else
@@ -145,7 +145,7 @@ module WillPaginate
         other.wp_count_options = @wp_count_options if defined? @wp_count_options
         other
       end
-      
+
       def select_for_count(rel)
         if rel.select_values.present?
           select = rel.select_values.join(", ")
@@ -198,7 +198,7 @@ module WillPaginate
       # +per_page+.
       #
       # Example:
-      # 
+      #
       #   @developers = Developer.paginate_by_sql ['select * from developers where salary > ?', 80000],
       #                          :page => params[:page], :per_page => 3
       #
@@ -206,7 +206,7 @@ module WillPaginate
       # supply <tt>:total_entries</tt>. If you experience problems with this
       # generated SQL, you might want to perform the count manually in your
       # application.
-      # 
+      #
       def paginate_by_sql(sql, options)
         pagenum  = options.fetch(:page) { raise ArgumentError, ":page parameter required" } || 1
         per_page = options[:per_page] || self.per_page
@@ -222,8 +222,7 @@ module WillPaginate
             query = <<-SQL
               SELECT * FROM (
                 SELECT rownum rnum, a.* FROM (#{query}) a
-                WHERE rownum <= #{pager.offset + pager.per_page}
-              ) WHERE rnum >= #{pager.offset}
+              ) WHERE rnum >= #{pager.offset} AND rnum <= #{pager.offset + pager.per_page}
             SQL
           else
             query << " LIMIT #{pager.per_page} OFFSET #{pager.offset}"

--- a/will_paginate.gemspec
+++ b/will_paginate.gemspec
@@ -5,18 +5,18 @@ require File.expand_path('../lib/will_paginate/version', __FILE__)
 Gem::Specification.new do |s|
   s.name    = 'will_paginate'
   s.version = WillPaginate::VERSION::STRING
-  
+
   s.summary = "Pagination plugin for web frameworks and other apps"
   s.description = "will_paginate provides a simple API for performing paginated queries with Active Record, DataMapper and Sequel, and includes helpers for rendering pagination links in Rails, Sinatra and Merb web apps."
-  
-  s.authors  = ['Mislav Marohnić']
+
+  s.authors  = ['Mislav Marohnic']
   s.email    = 'mislav.marohnic@gmail.com'
   s.homepage = 'https://github.com/mislav/will_paginate/wiki'
   s.license  = 'MIT'
-  
+
   s.rdoc_options = ['--main', 'README.md', '--charset=UTF-8']
   s.extra_rdoc_files = ['README.md', 'LICENSE']
-  
+
   s.files = Dir['Rakefile', '{bin,lib,test,spec}/**/*', 'README*', 'LICENSE*']
 
   # include only files in version control
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
     RbConfig::CONFIG['host_os'] =~ /msdos|mswin|djgpp|mingw/ ? 'NUL' : '/dev/null'
 
   if File.directory?(git_dir) and system "git --version >>#{void} 2>&1"
-    s.files &= `git --git-dir='#{git_dir}' ls-files -z`.split("\0") 
+    s.files &= `git --git-dir='#{git_dir}' ls-files -z`.split("\0")
   end
 end


### PR DESCRIPTION
Optimization of Oracle-SQL-Statement:

Do not calculate `rownum` for each inner select separatly. Make use of `raw_rnum_` instead.
