### PR TITLE
refactor out unless/else statement

### DIFF
--- a/lib/will_paginate/view_helpers/link_renderer.rb
+++ b/lib/will_paginate/view_helpers/link_renderer.rb
@@ -41,10 +41,10 @@ module WillPaginate
     protected
     
       def page_number(page)
-        unless page == current_page
-          link(page, page, :rel => rel_value(page))
-        else
+        if page == current_page
           tag(:em, page, :class => 'current')
+        else
+          link(page, page, :rel => rel_value(page))
         end
       end
       


### PR DESCRIPTION
Just a really small style change as it was bugging me while writing a link renderer. 

This replaces the use of an `unless/else` statement with its corresponding `if/else` statement. https://github.com/bbatsov/ruby-style-guide#no-else-with-unless