### PR TITLE
Collection infer

### DIFF
--- a/lib/will_paginate/view_helpers/action_view.rb
+++ b/lib/will_paginate/view_helpers/action_view.rb
@@ -89,7 +89,7 @@ module WillPaginate
     protected
 
     def infer_collection_from_controller
-      collection_name = "@#{controller.controller_name}"
+      collection_name = "@#{controller.class.name.gsub(/Controller$/, '').underscore.tr('/', '_')}"
       collection = instance_variable_get(collection_name)
       raise ArgumentError, "The #{collection_name} variable appears to be empty. Did you " +
         "forget to pass the collection object for will_paginate?" if collection.nil?

--- a/spec/view_helpers/action_view_spec.rb
+++ b/spec/view_helpers/action_view_spec.rb
@@ -32,18 +32,18 @@ describe WillPaginate::ActionView do
     @request = @controller.request
     @template = '<%= will_paginate collection, options %>'
   end
-  
+
   attr_reader :assigns, :controller, :request
-  
+
   def render(locals)
     @view = ActionView::Base.new([], @assigns, @controller)
     @view.request = @request
     @view.singleton_class.send(:include, @controller._routes.url_helpers)
     @view.render(:inline => @template, :locals => locals)
   end
-  
+
   ## basic pagination ##
-  
+
   it "should render" do
     paginate do |pagination|
       assert_select 'a[href]', 3 do |elements|
@@ -98,11 +98,11 @@ describe WillPaginate::ActionView do
   it "should paginate using a custom renderer instance" do
     renderer = WillPaginate::ActionView::LinkRenderer.new
     def renderer.gap() '<span class="my-gap">~~</span>' end
-    
+
     paginate({ :per_page => 2 }, :inner_window => 0, :outer_window => 0, :renderer => renderer) do
       assert_select 'span.my-gap', '~~'
     end
-    
+
     renderer = AdditionalLinkAttributesRenderer.new(:title => 'rendered')
     paginate({}, :renderer => renderer) do
       assert_select 'a[title=rendered]', 3
@@ -127,20 +127,20 @@ describe WillPaginate::ActionView do
     HTML
     expected.strip!.gsub!(/\s{2,}/, ' ')
     expected_dom = HTML::Document.new(expected).root
-    
+
     html_document.root.should == expected_dom
   end
-  
+
   it "should output escaped URLs" do
     paginate({:page => 1, :per_page => 1, :total_entries => 2},
              :page_links => false, :params => { :tag => '<br>' })
-    
+
     assert_select 'a[href]', 1 do |links|
       query = links.first['href'].split('?', 2)[1]
       query.split('&amp;').sort.should == %w(page=2 tag=%3Cbr%3E)
     end
   end
-  
+
   ## advanced options for pagination ##
 
   it "should be able to render without container" do
@@ -158,14 +158,14 @@ describe WillPaginate::ActionView do
   end
 
   ## other helpers ##
-  
+
   it "should render a paginated section" do
     @template = <<-ERB
       <%= paginated_section collection, options do %>
         <%= content_tag :div, '', :id => "developers" %>
       <% end %>
     ERB
-    
+
     paginate
     assert_select 'div.pagination', 2
     assert_select 'div.pagination + div#developers', 1
@@ -182,9 +182,9 @@ describe WillPaginate::ActionView do
     assert_select 'div.pagination', 0
     assert_select 'div#developers', 1
   end
-  
+
   ## parameter handling in page links ##
-  
+
   it "should preserve parameters on GET" do
     request.params :foo => { :bar => 'baz' }
     paginate
@@ -199,46 +199,46 @@ describe WillPaginate::ActionView do
     assert_no_links_match /99/
     assert_no_links_match /ftp/
   end
-  
+
   it "should not preserve parameters on POST" do
     request.post
     request.params :foo => 'bar'
     paginate
     assert_no_links_match /foo=bar/
   end
-  
+
   it "should add additional parameters to links" do
     paginate({}, :params => { :foo => 'bar' })
     assert_links_match /foo=bar/
   end
-  
+
   it "should add anchor parameter" do
     paginate({}, :params => { :anchor => 'anchor' })
     assert_links_match /#anchor$/
   end
-  
+
   it "should remove arbitrary parameters" do
     request.params :foo => 'bar'
     paginate({}, :params => { :foo => nil })
     assert_no_links_match /foo=bar/
   end
-    
+
   it "should override default route parameters" do
     paginate({}, :params => { :controller => 'baz', :action => 'list' })
     assert_links_match %r{\Wbaz/list\W}
   end
-  
+
   it "should paginate with custom page parameter" do
     paginate({ :page => 2 }, :param_name => :developers_page) do
       assert_select 'a[href]', 4 do |elements|
         validate_page_numbers [1,1,3,3], elements, :developers_page
       end
-    end    
+    end
   end
-  
+
   it "should paginate with complex custom page parameter" do
     request.params :developers => { :page => 2 }
-    
+
     paginate({ :page => 2 }, :param_name => 'developers[page]') do
       assert_select 'a[href]', 4 do |links|
         assert_links_match /\?developers\[page\]=\d+$/, links
@@ -281,21 +281,19 @@ describe WillPaginate::ActionView do
   it "should be able to guess the collection name" do
     collection = mock
     collection.expects(:total_pages).returns(1)
-    
+
     @template = '<%= will_paginate options %>'
-    controller.controller_name = 'developers'
-    assigns['developers'] = collection
-    
+    assigns['dummy'] = collection
+
     paginate(nil)
   end
-  
+
   it "should fail if the inferred collection is nil" do
     @template = '<%= will_paginate options %>'
-    controller.controller_name = 'developers'
-    
+
     lambda {
       paginate(nil)
-    }.should raise_error(ActionView::TemplateError, /@developers/)
+    }.should raise_error(ActionView::TemplateError, /@dummy/)
   end
 
   ## i18n
@@ -370,11 +368,10 @@ end
 
 class DummyController
   attr_reader :request
-  attr_accessor :controller_name
-  
+
   include ActionController::UrlFor
   include Routes.url_helpers
-  
+
   def initialize
     @request = DummyRequest.new
   end
@@ -398,13 +395,13 @@ end
 class DummyRequest
   attr_accessor :symbolized_path_parameters
   alias :path_parameters :symbolized_path_parameters
-  
+
   def initialize
     @get = true
     @params = {}
     @symbolized_path_parameters = { :controller => 'foo', :action => 'bar' }
   end
-  
+
   def get?
     @get
   end
@@ -416,7 +413,7 @@ class DummyRequest
   def relative_url_root
     ''
   end
-  
+
   def script_name
     ''
   end
@@ -425,7 +422,7 @@ class DummyRequest
     @params.update(more) if more
     @params
   end
-  
+
   def host_with_port
     'example.com'
   end
@@ -434,7 +431,7 @@ class DummyRequest
   def optional_port
     ''
   end
-  
+
   def protocol
     'http:'
   end


### PR DESCRIPTION
It will no longer ignore namespaced controllers when attempting to infer the instance variable for the collection.  For example:

```shell
$ rails g scaffold admin/articles title body:text
```

```html
<!-- in app/views/admin/articles/index.html.erb -->
<%= will_paginate(nil) %>
```

Before the patch, it would infer `@articles` as the collection; unfortunately, this is not what Rails generates.  The proper instance variable would be `@admin_articles`, which is what it generates after
the patch.