### PR TITLE
Operate with i18n.load_path, not i18n.railties_load_path

### DIFF
--- a/lib/will_paginate/railtie.rb
+++ b/lib/will_paginate/railtie.rb
@@ -32,7 +32,7 @@ module WillPaginate
     end
 
     def self.add_locale_path(config)
-      config.i18n.railties_load_path.unshift(*WillPaginate::I18n.load_path)
+      config.i18n.load_path.unshift(*WillPaginate::I18n.load_path)
     end
 
     # Extending the exception handler middleware so it properly detects


### PR DESCRIPTION
After Rails update [1], `railties_load_path` stores `Rails::Paths::Path` instances only.
Modifying `I18n.load_path` is the common approach, which is also used by other gems [2]

[1] https://github.com/rails/rails/pull/21124
[2] https://github.com/rails/rails/blob/master/activemodel/lib/active_model.rb#L71