### PR TITLE
Fix locale loading so that it loads earlier than the app's locales

### DIFF
--- a/lib/will_paginate/railtie.rb
+++ b/lib/will_paginate/railtie.rb
@@ -18,8 +18,6 @@ module WillPaginate
         require 'will_paginate/view_helpers/action_view'
       end
 
-      self.class.add_locale_path config
-
       # early access to ViewHelpers.pagination_options
       require 'will_paginate/view_helpers'
     end
@@ -29,10 +27,6 @@ module WillPaginate
         ActionDispatch::ExceptionWrapper : ActionDispatch::ShowExceptions
       ).send :include, ShowExceptionsPatch
       ActionController::Base.extend ControllerRescuePatch
-    end
-
-    def self.add_locale_path(config)
-      config.i18n.load_path.unshift(*WillPaginate::I18n.load_path)
     end
 
     # Extending the exception handler middleware so it properly detects
@@ -68,4 +62,8 @@ module WillPaginate
       end
     end
   end
+end
+
+ActiveSupport.on_load :i18n do
+  WillPaginate::I18n.load_path.each { |path| I18n.load_path << path }
 end


### PR DESCRIPTION
When I upgraded `will_paginate` from 3.0.3 to 3.1.0 (while upgrading our app from Rails 3.2 to Rails 4.2) I ran into an issue where it was ignoring the custom translations we had in our app's locale file. 

Specifically, we had this:

```
# config/locales/will_paginate.en.yml
en:
  will_paginate:
    previous_label: "&laquo;"
    next_label: "&raquo;"
    page_gap: "&hellip;"
```

In the UI, it showed the default text for previous and next labels.

```
← Previous 1 2 3 4 5 6 7 8 9 … 122 123 Next →
```

With the older version of `will_paginate` it was showing the correct text:

```
« 1 2 3 4 5 6 7 8 9 … 122 123 »
```

I think this is also reported in bugs #378 and #392.

The issue is that the `I18n.load_path` ends up having `will_paginate` locales loaded _after_ the app's locale files. 

```
2.3.0 :001 > I18n.load_path.select { |s| s =~ /will_paginate/ }
 => ["app-code-path/config/locales/will_paginate.en.yml", "gem-path/will_paginate-3.1.0/lib/will_paginate/locale/en.yml"] 
```

I believe this is was caused by the change at 6bfa7482. The links in the commit message point to ActiveRecord adding to `I18n.load_path` but that code in ActiveRecord is actually run when the file is required. I've changed this to follow the same pattern that ActiveRecord does in [4.0-stable branch](https://github.com/rails/rails/blob/4-0-stable/activemodel/lib/active_model.rb#L71) (which is the same in master at this time). That is, to configure the `on_load` for I18n when the file is required, rather than when the railtie is initialized.

I have tested this in my own app, but did not write a spec. Short of adding an app to the gem for testing (and it would need a Rails app for each version of rails it's tested against), I'm not sure how to write an automated test for this.