### PR TITLE
Rails 5 compatibility: url query params

### DIFF
--- a/lib/will_paginate/view_helpers/link_renderer.rb
+++ b/lib/will_paginate/view_helpers/link_renderer.rb
@@ -119,7 +119,7 @@ module WillPaginate
           key = key.to_sym
           existing = target[key]
           
-          if value.is_a?(Hash) and (existing.is_a?(Hash) or existing.nil?)
+          if (value.is_a?(ActionController::Parameters) or value.is_a?(Hash)) and (existing.is_a?(Hash) or existing.nil?)
             symbolized_update(existing || (target[key] = {}), value)
           else
             target[key] = value


### PR DESCRIPTION
As "params" is now an `ActionController::Parameters` and not an `Hash`, in rails 5, the method that set query parameters in url should be fixed, to take this change in consideration.
Without this change, we go to the else statement and assign to target `target[key]=value` an `ActionController::Parameters` object, instead of a `String`

Let me know if I should write a spec for this change.

Also, I let the test `value.is_a?(Hash)` to support compatibility with prior rails version.

Thanks for your work on this gem.