### PR TITLE
Avoid creating one extra "LIMIT 1" query when using page_entries_info

### DIFF
--- a/lib/will_paginate/view_helpers.rb
+++ b/lib/will_paginate/view_helpers.rb
@@ -104,7 +104,7 @@ module WillPaginate
     # The default output contains HTML. Use ":html => false" for plain text.
     def page_entries_info(collection, options = {})
       model = options[:model]
-      model = collection.first.class unless model or collection.empty?
+      model = collection.klass unless model or collection.empty?
       model ||= 'entry'
       model_key = if model.respond_to? :model_name
                     model.model_name.i18n_key  # ActiveModel::Naming


### PR DESCRIPTION
Calling "collection.first" causes one extra DB query