### PR TITLE
Updates README to use 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Installation:
 
 ``` ruby
 ## Gemfile for Rails 3+, Sinatra, and Merb
-gem 'will_paginate', '~> 3.0.6'
+gem 'will_paginate', '~> 3.1.0'
 ```
 
 See [installation instructions][install] on the wiki for more info.


### PR DESCRIPTION
The current **README.md** indicates an outdated version in the Gemfile section. This could lead users to be using outdated versions of the software.

It looks like v3.1.0 is not backward compatible with v3.0.7 and before, but the documentation should probably reflect the latest version regardless.