### PR TITLE
Make last pages links optional

### DIFF
--- a/lib/will_paginate/view_helpers.rb
+++ b/lib/will_paginate/view_helpers.rb
@@ -26,6 +26,7 @@ module WillPaginate
       :next_label     => nil,
       :inner_window   => 4, # links around the current page
       :outer_window   => 1, # links around beginning and end
+      :last_page      => true,
       :link_separator => ' ', # single space is friendly to spiders and non-graphic browsers
       :param_name     => :page,
       :params         => nil,
@@ -42,13 +43,14 @@ module WillPaginate
 
     # Returns HTML representing page links for a WillPaginate::Collection-like object.
     # In case there is no more than one page in total, nil is returned.
-    # 
+    #
     # ==== Options
     # * <tt>:class</tt> -- CSS class name for the generated DIV (default: "pagination")
     # * <tt>:previous_label</tt> -- default: "« Previous"
     # * <tt>:next_label</tt> -- default: "Next »"
     # * <tt>:inner_window</tt> -- how many links are shown around the current page (default: 4)
     # * <tt>:outer_window</tt> -- how many links are around the first and the last page (default: 1)
+    # * <tt>:last_page</tt> -- when false, the last page link is not rendered (default: true)
     # * <tt>:link_separator</tt> -- string separator for page HTML elements (default: single space)
     # * <tt>:param_name</tt> -- parameter name for page number in URLs (default: <tt>:page</tt>)
     # * <tt>:params</tt> -- additional parameters when generating pagination links

--- a/lib/will_paginate/view_helpers/link_renderer_base.rb
+++ b/lib/will_paginate/view_helpers/link_renderer_base.rb
@@ -53,13 +53,14 @@ module WillPaginate
         end
 
         # right window
+        last_page = @options[:last_page].nil? || @options[:last_page]
         if total_pages - outer_window - 2 > middle.last # again, gap
-          right = ((total_pages - outer_window)..total_pages).to_a
+          right = last_page ? ((total_pages - outer_window)..total_pages).to_a : []
           right.unshift :gap
         else # runs into visible pages
-          right = (middle.last + 1)..total_pages
+          right = last_page ? (middle.last + 1)..total_pages : []
         end
-        
+
         left.to_a + middle.to_a + right.to_a
       end
 

--- a/lib/will_paginate/view_helpers/link_renderer_base.rb
+++ b/lib/will_paginate/view_helpers/link_renderer_base.rb
@@ -53,12 +53,12 @@ module WillPaginate
         end
 
         # right window
-        last_page = @options[:last_page].nil? || @options[:last_page]
+        display_last_pages = @options[:last_page].nil? || @options[:last_page]
         if total_pages - outer_window - 2 > middle.last # again, gap
-          right = last_page ? ((total_pages - outer_window)..total_pages).to_a : []
+          right = display_last_pages ? ((total_pages - outer_window)..total_pages).to_a : []
           right.unshift :gap
         else # runs into visible pages
-          right = last_page ? (middle.last + 1)..total_pages : []
+          right = display_last_pages ? (middle.last + 1)..total_pages : []
         end
 
         left.to_a + middle.to_a + right.to_a

--- a/spec/view_helpers/link_renderer_base_spec.rb
+++ b/spec/view_helpers/link_renderer_base_spec.rb
@@ -3,27 +3,27 @@ require 'will_paginate/view_helpers/link_renderer_base'
 require 'will_paginate/collection'
 
 describe WillPaginate::ViewHelpers::LinkRendererBase do
-  
+
   before do
     @renderer = described_class.new
   end
-  
+
   it "should raise error when unprepared" do
     lambda {
       @renderer.pagination
     }.should raise_error
   end
-  
+
   it "should prepare with collection and options" do
     prepare({})
     @renderer.send(:current_page).should == 1
   end
-  
+
   it "should have total_pages accessor" do
     prepare :total_pages => 42
     @renderer.send(:total_pages).should == 42
   end
-  
+
   it "should clear old cached values when prepared" do
     prepare(:total_pages => 1)
     @renderer.send(:total_pages).should == 1
@@ -31,45 +31,50 @@ describe WillPaginate::ViewHelpers::LinkRendererBase do
     prepare(:total_pages => 2)
     @renderer.send(:total_pages).should == 2
   end
-  
+
   it "should have pagination definition" do
     prepare({ :total_pages => 1 }, :page_links => true)
     @renderer.pagination.should == [:previous_page, 1, :next_page]
   end
-  
+
   describe "visible page numbers" do
     it "should calculate windowed visible links" do
       prepare({ :page => 6, :total_pages => 11 }, :inner_window => 1, :outer_window => 1)
       showing_pages 1, 2, :gap, 5, 6, 7, :gap, 10, 11
     end
-  
+
     it "should eliminate small gaps" do
       prepare({ :page => 6, :total_pages => 11 }, :inner_window => 2, :outer_window => 1)
       # pages 4 and 8 appear instead of the gap
       showing_pages 1..11
     end
-    
+
     it "should support having no windows at all" do
       prepare({ :page => 4, :total_pages => 7 }, :inner_window => 0, :outer_window => 0)
       showing_pages 1, :gap, 4, :gap, 7
     end
-    
+
     it "should adjust upper limit if lower is out of bounds" do
       prepare({ :page => 1, :total_pages => 10 }, :inner_window => 2, :outer_window => 1)
       showing_pages 1, 2, 3, 4, 5, :gap, 9, 10
     end
-    
+
     it "should adjust lower limit if upper is out of bounds" do
       prepare({ :page => 10, :total_pages => 10 }, :inner_window => 2, :outer_window => 1)
       showing_pages 1, 2, :gap, 6, 7, 8, 9, 10
     end
-    
+
+    it "should support not having last page" do
+      prepare({ :page => 7, :total_pages => 31 }, :inner_window => 1, :outer_window => 1, :last_page => false)
+      showing_pages 1, 2, :gap, 6, 7, 8, :gap
+    end
+
     def showing_pages(*pages)
       pages = pages.first.to_a if Array === pages.first or Range === pages.first
       @renderer.send(:windowed_page_numbers).should == pages
     end
   end
-  
+
   protected
 
     def collection(params = {})
@@ -83,5 +88,5 @@ describe WillPaginate::ViewHelpers::LinkRendererBase do
     def prepare(collection_options, options = {})
       @renderer.prepare(collection(collection_options), options)
     end
-  
+
 end


### PR DESCRIPTION
This pull request solves issue #461 - Removing link to last pages.

It adds the option `last_page` to the renderer will_paginate, **allowing pagination links to not display the last pages**.
`last_page`'s default value is true, and when it's value is false, links of last pages are not rendered.

### Usage example

#### Default
```ruby
<%= will_paginate(@posts, inner_window: 1, outer_window: 2) %>
```
Result:
<img width="656" alt="default pagination links" src="https://cloud.githubusercontent.com/assets/3089218/14824031/e2c56266-0baa-11e6-9a31-3193cf67b922.png">

#### Using `last_page: false`
```ruby
<%= will_paginate(@posts, inner_window: 1, outer_window: 2, last_page: false) %>
```
Result:
<img width="656" alt="pagination links with no last pages" src="https://cloud.githubusercontent.com/assets/3089218/14824094/15a68caa-0bab-11e6-9303-6b3886b4ee32.png">
