### PR TITLE
Add scope to will_paginate helper to allow using it in namespaced engines

### DIFF
--- a/lib/will_paginate/view_helpers.rb
+++ b/lib/will_paginate/view_helpers.rb
@@ -30,7 +30,8 @@ module WillPaginate
       :param_name     => :page,
       :params         => nil,
       :page_links     => true,
-      :container      => true
+      :container      => true,
+      :scope          => nil
 
     label_deprecation = Proc.new { |key, value|
       "set the 'will_paginate.#{key}' key in your i18n locale instead of editing pagination_options" if defined? Rails

--- a/lib/will_paginate/view_helpers/action_view.rb
+++ b/lib/will_paginate/view_helpers/action_view.rb
@@ -115,7 +115,7 @@ module WillPaginate
         url_params = @base_url_params.dup
         add_current_page_param(url_params, page)
 
-        @template.url_for(url_params)
+        (@options[:scope] || @template).url_for(url_params)
       end
 
       def merge_get_params(url_params)


### PR DESCRIPTION
This PR is another take to mislav/will_paginate/pull/172 that doesn't require the scope param to be in the "params" hash. It can be used as follows:

``` ruby
will_paginate @results, scope: my_engine
```
