### PR TITLE
Add very basic API support for pagination items

### DIFF
--- a/lib/will_paginate/collection.rb
+++ b/lib/will_paginate/collection.rb
@@ -37,10 +37,10 @@ module WillPaginate
       # Helper method to eturn pagination options as a JSON object
       # usefull on API responses
       {
-        current_page: current_page,
-        per_page: per_page,
-        total_entries: total_entries,
-        total_pages: total_pages
+        :current_page => current_page,
+        :per_page => per_page,
+        :total_entries => total_entries,
+        :total_pages => total_pages
       }
     end
   end

--- a/lib/will_paginate/collection.rb
+++ b/lib/will_paginate/collection.rb
@@ -32,6 +32,17 @@ module WillPaginate
     def out_of_bounds?
       current_page > total_pages
     end
+
+    def api_pagination
+      # Helper method to eturn pagination options as a JSON object
+      # usefull on API responses
+      {
+        current_page: current_page,
+        per_page: per_page,
+        total_entries: total_entries,
+        total_pages: total_pages
+      }
+    end
   end
 
   # = The key to pagination
@@ -42,7 +53,7 @@ module WillPaginate
   #
   # WillPaginate::Collection also assists in rolling out your own pagination
   # solutions: see +create+.
-  # 
+  #
   # If you are writing a library that provides a collection which you would like
   # to conform to this API, you don't have to copy these methods over; simply
   # make your plugin/gem dependant on this library and do:
@@ -123,7 +134,7 @@ module WillPaginate
     # in +create+.
     def replace(array)
       result = super
-      
+
       # The collection is shorter then page limit? Rejoice, because
       # then we know that we are on the last page!
       if total_entries.nil? and length < per_page and (current_page == 1 or length > 0)

--- a/lib/will_paginate/collection.rb
+++ b/lib/will_paginate/collection.rb
@@ -40,7 +40,9 @@ module WillPaginate
         :current_page => current_page,
         :per_page => per_page,
         :total_entries => total_entries,
-        :total_pages => total_pages
+        :total_pages => total_pages,
+        :previous_page => previous_page,
+        :next_page => next_page
       }
     end
   end

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -22,7 +22,7 @@ describe WillPaginate::Collection do
   it "should be empty if out of bounds" do
     @simple.paginate(:page => 2, :per_page => 5).should be_empty
   end
-  
+
   it "should default to 1 as current page and 30 per-page" do
     result = (1..50).to_a.paginate
     result.current_page.should == 1
@@ -57,13 +57,13 @@ describe WillPaginate::Collection do
       collection.previous_page.should be_nil
       collection.next_page.should == 2
     end
-    
+
     it "should have both prev/next pages" do
       collection = create(2, 1, 3)
       collection.previous_page.should == 1
       collection.next_page.should == 3
     end
-    
+
     it "should have next_page nil when on last page" do
       collection = create(3, 1, 3)
       collection.previous_page.should == 2
@@ -92,22 +92,22 @@ describe WillPaginate::Collection do
       collection = create { |p| p.replace array }
       collection.total_entries.should == 8
     end
-    
+
     it "should allow explicit total count to override guessed" do
       collection = create(2, 5, 10) { |p| p.replace array }
       collection.total_entries.should == 10
     end
-    
+
     it "should not be able to guess when collection is same as limit" do
       collection = create { |p| p.replace array(5) }
       collection.total_entries.should be_nil
     end
-    
+
     it "should not be able to guess when collection is empty" do
       collection = create { |p| p.replace array(0) }
       collection.total_entries.should be_nil
     end
-    
+
     it "should be able to guess when collection is empty and this is the first page" do
       collection = create(1) { |p| p.replace array(0) }
       collection.total_entries.should == 0
@@ -123,8 +123,19 @@ describe WillPaginate::Collection do
     collection.per_page.should == 30
   end
 
+  describe 'api_pagination' do
+    it 'should return all options in an object' do
+      collection = @simple.paginate(:page => 1, :per_page => 3)
+      collection.api_pagination.should be_kind_of Hash
+      collection.api_pagination[:current_page].should == 1
+      collection.api_pagination[:total_entries].should == 5
+      collection.api_pagination[:per_page].should == 3
+      collection.api_pagination[:total_pages].should == 2
+    end
+  end
+
   private
-  
+
     def create(page = 2, limit = 5, total = nil, &block)
       if block_given?
         described_class.create(page, limit, total, &block)


### PR DESCRIPTION
First of all want to thank you for your awesome gem!! 🎉 

I was trying to implement _will_paginate_  in a API project and it was hard to do because of the use of the [AM Serializers](https://github.com/rails-api/active_model_serializers) so I came up with this solution. Probably not the fanciest solution but it can help others to have a better approach and keep using your gem ;)

So you need to use _will_paginate_ as usual. For example, lets say you have a Comments API and you can return your object/collection as follows:

```
def index
  @comments = Comment.paginate(page: params[:page], per_page: params[:per_page])

  render json: { comments: serialized_object(@comments), pagination: @comments.api_pagination }, status: 200
end

...

def serialized_object(object)
  ActiveModel::ArraySerializer.new(object.decorate,  each_serializer: CommentsSerializer)
end
```

With this you will have a response like:

```
{
  comments: [
    {
      comment: "lorem ipsum ",
      created_at: "2016-07-21T22:17:46.147Z",
      ...
    },
   {
      #... More comments suppressed for example purposes 
   }
  ],
  pagination: {
    current_page: 1,
    per_page: 3,
    total_entries: 11,
    total_pages: 4
  }
}
```

Please let me know your opinion or how can I improve this solution, I know it can looks a little bit 'hacky' but I think is better than having to add that 'patch' in every API implementation. 😆 