### PR TITLE
Fixnum deprecated, use Integer instead

### DIFF
--- a/lib/will_paginate/view_helpers/link_renderer.rb
+++ b/lib/will_paginate/view_helpers/link_renderer.rb
@@ -24,7 +24,7 @@ module WillPaginate
       # method as you see fit.
       def to_html
         html = pagination.map do |item|
-          item.is_a?(Fixnum) ?
+          item.is_a?(Integer) ?
             page_number(item) :
             send(item)
         end.join(@options[:link_separator])
@@ -88,7 +88,7 @@ module WillPaginate
       end
 
       def link(text, target, attributes = {})
-        if target.is_a? Fixnum
+        if target.is_a? Integer
           attributes[:rel] = rel_value(target)
           target = url(target)
         end

--- a/spec/page_number_spec.rb
+++ b/spec/page_number_spec.rb
@@ -23,12 +23,12 @@ describe WillPaginate::PageNumber do
       (num.is_a? Numeric).should be
     end
 
-    it "is a kind of Fixnum" do
-      (num.is_a? Fixnum).should be
+    it "is a kind of Integer" do
+      (num.is_a? Integer).should be
     end
 
-    it "isn't directly a Fixnum" do
-      (num.instance_of? Fixnum).should_not be
+    it "isn't directly a Integer" do
+      (num.instance_of? Integer).should_not be
     end
 
     it "passes the PageNumber=== type check" do |variable|
@@ -37,7 +37,7 @@ describe WillPaginate::PageNumber do
 
     it "passes the Numeric=== type check" do |variable|
       (Numeric === num).should be
-      (Fixnum === num).should be
+      (Integer === num).should be
     end
   end
 


### PR DESCRIPTION
Per https://bugs.ruby-lang.org/issues/12739