### PR TITLE
Fix deprecation warnings on Ruby 2.4.0

### DIFF
--- a/lib/will_paginate/page_number.rb
+++ b/lib/will_paginate/page_number.rb
@@ -40,7 +40,7 @@ module WillPaginate
     alias is_a? kind_of?
   end
 
-  # Ultrahax: makes `Fixnum === current_page` checks pass
+  # Ultrahax: makes `Integer === current_page` checks pass
   Numeric.extend Module.new {
     def ===(obj)
       obj.instance_of? PageNumber or super

--- a/lib/will_paginate/view_helpers/link_renderer.rb
+++ b/lib/will_paginate/view_helpers/link_renderer.rb
@@ -24,7 +24,7 @@ module WillPaginate
       # method as you see fit.
       def to_html
         html = pagination.map do |item|
-          item.is_a?(Fixnum) ?
+          item.is_a?(Integer) ?
             page_number(item) :
             send(item)
         end.join(@options[:link_separator])
@@ -88,7 +88,7 @@ module WillPaginate
       end
 
       def link(text, target, attributes = {})
-        if target.is_a? Fixnum
+        if target.is_a? Integer
           attributes[:rel] = rel_value(target)
           target = url(target)
         end

--- a/spec/page_number_spec.rb
+++ b/spec/page_number_spec.rb
@@ -23,12 +23,12 @@ describe WillPaginate::PageNumber do
       (num.is_a? Numeric).should be
     end
 
-    it "is a kind of Fixnum" do
-      (num.is_a? Fixnum).should be
+    it "is a kind of Integer" do
+      (num.is_a? 0.class).should be
     end
 
-    it "isn't directly a Fixnum" do
-      (num.instance_of? Fixnum).should_not be
+    it "isn't directly an Integer" do
+      (num.instance_of? 0.class).should_not be
     end
 
     it "passes the PageNumber=== type check" do |variable|
@@ -37,7 +37,7 @@ describe WillPaginate::PageNumber do
 
     it "passes the Numeric=== type check" do |variable|
       (Numeric === num).should be
-      (Fixnum === num).should be
+      (0.class === num).should be
     end
   end
 


### PR DESCRIPTION
Referencing the `Fixnum` constant issues a deprecation warning on Ruby
2.4.0:

    warning: constant ::Fixnum is deprecated

This commit suppresses it while keeping the code compatible with earlier
versions of Ruby.