### PR TITLE
Fix deprecation warnings for Ruby 2.4

### DIFF
--- a/lib/will_paginate/view_helpers/link_renderer.rb
+++ b/lib/will_paginate/view_helpers/link_renderer.rb
@@ -24,7 +24,7 @@ module WillPaginate
       # method as you see fit.
       def to_html
         html = pagination.map do |item|
-          item.is_a?(Fixnum) ?
+          item.is_a?(Integer) ?
             page_number(item) :
             send(item)
         end.join(@options[:link_separator])
@@ -88,7 +88,7 @@ module WillPaginate
       end
 
       def link(text, target, attributes = {})
-        if target.is_a? Fixnum
+        if target.is_a? Integer
           attributes[:rel] = rel_value(target)
           target = url(target)
         end

--- a/lib/will_paginate/view_helpers/link_renderer.rb
+++ b/lib/will_paginate/view_helpers/link_renderer.rb
@@ -24,7 +24,7 @@ module WillPaginate
       # method as you see fit.
       def to_html
         html = pagination.map do |item|
-          item.is_a?(Integer) ?
+          item.is_a?(0.class) ?
             page_number(item) :
             send(item)
         end.join(@options[:link_separator])
@@ -88,7 +88,7 @@ module WillPaginate
       end
 
       def link(text, target, attributes = {})
-        if target.is_a? Integer
+        if target.is_a? 0.class
           attributes[:rel] = rel_value(target)
           target = url(target)
         end

--- a/spec/page_number_spec.rb
+++ b/spec/page_number_spec.rb
@@ -23,12 +23,12 @@ describe WillPaginate::PageNumber do
       (num.is_a? Numeric).should be
     end
 
-    it "is a kind of Fixnum" do
+    it "Is a Ruby Fixnum/Integer" do
       (num.is_a? Fixnum).should be
     end
 
-    it "isn't directly a Fixnum" do
-      (num.instance_of? Fixnum).should_not be
+    it "isn't directly a Ruby Fixnum/Intege" do
+      (num.instance_of? (Fixnum == Integer ? Integer : Fixnum)).should_not be
     end
 
     it "passes the PageNumber=== type check" do |variable|

--- a/spec/page_number_spec.rb
+++ b/spec/page_number_spec.rb
@@ -24,11 +24,11 @@ describe WillPaginate::PageNumber do
     end
 
     it "Is a Ruby Fixnum/Integer" do
-      (num.is_a? Fixnum).should be
+      (num.is_a? 0.class).should be
     end
 
-    it "isn't directly a Ruby Fixnum/Intege" do
-      (num.instance_of? (Fixnum == Integer ? Integer : Fixnum)).should_not be
+    it "isn't directly a Ruby Fixnum/Integer" do
+      (num.instance_of? 0.class).should_not be
     end
 
     it "passes the PageNumber=== type check" do |variable|


### PR DESCRIPTION
Fixes deprecation warnings, as they're making my spec output hard to read