### PR TITLE
Allow to customize left and right gaps if needed

### DIFF
--- a/lib/will_paginate/view_helpers/link_renderer.rb
+++ b/lib/will_paginate/view_helpers/link_renderer.rb
@@ -8,7 +8,7 @@ module WillPaginate
     # This class does the heavy lifting of actually building the pagination
     # links. It is used by +will_paginate+ helper internally.
     class LinkRenderer < LinkRendererBase
-      
+
       # * +collection+ is a WillPaginate::Collection instance or any other object
       #   that conforms to that API
       # * +options+ are forwarded from +will_paginate+ view helper
@@ -28,7 +28,7 @@ module WillPaginate
             page_number(item) :
             send(item)
         end.join(@options[:link_separator])
-        
+
         @options[:container] ? html_container(html) : html
       end
 
@@ -37,9 +37,9 @@ module WillPaginate
       def container_attributes
         @container_attributes ||= @options.except(*(ViewHelpers.pagination_options.keys + [:renderer] - [:class]))
       end
-      
+
     protected
-    
+
       def page_number(page)
         if page == current_page
           tag(:em, page, :class => 'current')
@@ -47,22 +47,33 @@ module WillPaginate
           link(page, page, :rel => rel_value(page))
         end
       end
-      
+
       def gap
-        text = @template.will_paginate_translate(:page_gap) { '&hellip;' }
-        %(<span class="gap">#{text}</span>)
+        %(<span class="gap">#{gap_text}</span>)
       end
-      
+
+      def left_gap
+        gap
+      end
+
+      def right_gap
+        gap
+      end
+
+      def gap_text
+        @gap_text ||= @template.will_paginate_translate(:page_gap) { '&hellip;' }
+      end
+
       def previous_page
         num = @collection.current_page > 1 && @collection.current_page - 1
         previous_or_next_page(num, @options[:previous_label], 'previous_page')
       end
-      
+
       def next_page
         num = @collection.current_page < total_pages && @collection.current_page + 1
         previous_or_next_page(num, @options[:next_label], 'next_page')
       end
-      
+
       def previous_or_next_page(page, text, classname)
         if page
           link(text, page, :class => classname)
@@ -70,17 +81,17 @@ module WillPaginate
           tag(:span, text, :class => classname + ' disabled')
         end
       end
-      
+
       def html_container(html)
         tag(:div, html, container_attributes)
       end
-      
+
       # Returns URL params for +page_link_or_span+, taking the current GET params
       # and <tt>:params</tt> option into account.
       def url(page)
         raise NotImplementedError
       end
-      
+
     private
 
       def param_name
@@ -95,7 +106,7 @@ module WillPaginate
         attributes[:href] = target
         tag(:a, text, attributes)
       end
-      
+
       def tag(name, value, attributes = {})
         string_attributes = attributes.inject('') do |attrs, pair|
           unless pair.last.nil?

--- a/lib/will_paginate/view_helpers/link_renderer_base.rb
+++ b/lib/will_paginate/view_helpers/link_renderer_base.rb
@@ -14,7 +14,7 @@ module WillPaginate
         # reset values in case we're re-using this instance
         @total_pages = nil
       end
-      
+
       def pagination
         items = @options[:page_links] ? windowed_page_numbers : []
         items.unshift :previous_page
@@ -22,14 +22,14 @@ module WillPaginate
       end
 
     protected
-    
+
       # Calculates visible page numbers using the <tt>:inner_window</tt> and
       # <tt>:outer_window</tt> options.
       def windowed_page_numbers
         inner_window, outer_window = @options[:inner_window].to_i, @options[:outer_window].to_i
         window_from = current_page - inner_window
         window_to = current_page + inner_window
-        
+
         # adjust lower or upper limit if either is out of bounds
         if window_to > total_pages
           window_from -= window_to - total_pages
@@ -40,14 +40,14 @@ module WillPaginate
           window_from = 1
           window_to = total_pages if window_to > total_pages
         end
-        
+
         # these are always visible
         middle = window_from..window_to
 
         # left window
         if outer_window + 3 < middle.first # there's a gap
           left = (1..(outer_window + 1)).to_a
-          left << :gap
+          left << :left_gap
         else # runs into visible pages
           left = 1...middle.first
         end
@@ -55,11 +55,11 @@ module WillPaginate
         # right window
         if total_pages - outer_window - 2 > middle.last # again, gap
           right = ((total_pages - outer_window)..total_pages).to_a
-          right.unshift :gap
+          right.unshift :right_gap
         else # runs into visible pages
           right = (middle.last + 1)..total_pages
         end
-        
+
         left.to_a + middle.to_a + right.to_a
       end
 

--- a/spec/view_helpers/link_renderer_base_spec.rb
+++ b/spec/view_helpers/link_renderer_base_spec.rb
@@ -40,7 +40,7 @@ describe WillPaginate::ViewHelpers::LinkRendererBase do
   describe "visible page numbers" do
     it "should calculate windowed visible links" do
       prepare({ :page => 6, :total_pages => 11 }, :inner_window => 1, :outer_window => 1)
-      showing_pages 1, 2, :gap, 5, 6, 7, :gap, 10, 11
+      showing_pages 1, 2, :left_gap, 5, 6, 7, :right_gap, 10, 11
     end
   
     it "should eliminate small gaps" do
@@ -51,17 +51,17 @@ describe WillPaginate::ViewHelpers::LinkRendererBase do
     
     it "should support having no windows at all" do
       prepare({ :page => 4, :total_pages => 7 }, :inner_window => 0, :outer_window => 0)
-      showing_pages 1, :gap, 4, :gap, 7
+      showing_pages 1, :left_gap, 4, :right_gap, 7
     end
     
     it "should adjust upper limit if lower is out of bounds" do
       prepare({ :page => 1, :total_pages => 10 }, :inner_window => 2, :outer_window => 1)
-      showing_pages 1, 2, 3, 4, 5, :gap, 9, 10
+      showing_pages 1, 2, 3, 4, 5, :right_gap, 9, 10
     end
     
     it "should adjust lower limit if upper is out of bounds" do
       prepare({ :page => 10, :total_pages => 10 }, :inner_window => 2, :outer_window => 1)
-      showing_pages 1, 2, :gap, 6, 7, 8, 9, 10
+      showing_pages 1, 2, :left_gap, 6, 7, 8, 9, 10
     end
     
     def showing_pages(*pages)


### PR DESCRIPTION
If you need to customize gaps as links you can do so:

```ruby
  # For example you want to build link to second page before and
  # after current page respectively instead of simple span with ellipsis
  #
  # To access gap translation from locales you can use gap_text method
  #
  class CustomRenderer < WillPaginate::ActionView::LinkRenderer
    def left_gap
      # ... some logic
      link(gap_text, page, attributes)
    end

    def right_gap
      # ... some logic
      link(gap_text, page, attributes)
    end
  end
```