### PR TITLE
Discourage `will_paginate/array`, introduce WillPaginate::ArrayMixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,18 @@ Post.where(:published => true).paginate(:page => params[:page]).order('id DESC')
 Post.page(params[:page]).order('created_at DESC')
 ```
 
-See [the wiki][wiki] for more documentation. [Report bugs][issues] on GitHub.
+
+## On pagination of arbitrary arrays
+
+It is often suggested to `require 'will_paginate/array'` in order to paginate any arbitrary array, but changing a common class globally is often an anti-pattern which can lead to name clashes. Instead, one is encouraged to extend a particular object:
+
+```ruby
+array.extend(WillPaginate::ArrayMixin).paginate(page: page, per_page: per_page)
+```
+
+See [the wiki][wiki] for more documentation. [Ask on the group][group] if you have usage questions. [Report bugs][issues] on GitHub.
 
 Happy paginating.
-
 
 [wiki]: https://github.com/mislav/will_paginate/wiki
 [install]: https://github.com/mislav/will_paginate/wiki/Installation "will_paginate installation"

--- a/lib/will_paginate/array.rb
+++ b/lib/will_paginate/array.rb
@@ -1,33 +1,5 @@
 require 'will_paginate/collection'
 
 class Array
-  # Paginates a static array (extracting a subset of it). The result is a
-  # WillPaginate::Collection instance, which is an array with a few more
-  # properties about its paginated state.
-  #
-  # Parameters:
-  # * <tt>:page</tt> - current page, defaults to 1
-  # * <tt>:per_page</tt> - limit of items per page, defaults to 30
-  # * <tt>:total_entries</tt> - total number of items in the array, defaults to
-  #   <tt>array.length</tt> (obviously)
-  #
-  # Example:
-  #   arr = ['a', 'b', 'c', 'd', 'e']
-  #   paged = arr.paginate(:per_page => 2)      #->  ['a', 'b']
-  #   paged.total_entries                       #->  5
-  #   arr.paginate(:page => 2, :per_page => 2)  #->  ['c', 'd']
-  #   arr.paginate(:page => 3, :per_page => 2)  #->  ['e']
-  #
-  # This method was originally {suggested by Desi
-  # McAdam}[http://www.desimcadam.com/archives/8] and later proved to be the
-  # most useful method of will_paginate library.
-  def paginate(options = {})
-    page     = options[:page] || 1
-    per_page = options[:per_page] || WillPaginate.per_page
-    total    = options[:total_entries] || self.length
-
-    WillPaginate::Collection.create(page, per_page, total) do |pager|
-      pager.replace self[pager.offset, pager.per_page].to_a
-    end
-  end
+  include WillPaginate::ArrayMixin
 end

--- a/lib/will_paginate/array_mixin.rb
+++ b/lib/will_paginate/array_mixin.rb
@@ -1,0 +1,34 @@
+module WillPaginate
+  module ArrayMixin
+    # Paginates a static array (extracting a subset of it). The result is a
+    # WillPaginate::Collection instance, which is an array with a few more
+    # properties about its paginated state.
+    #
+    # Parameters:
+    # * <tt>:page</tt> - current page, defaults to 1
+    # * <tt>:per_page</tt> - limit of items per page, defaults to 30
+    # * <tt>:total_entries</tt> - total number of items in the array, defaults to
+    #   <tt>array.length</tt> (obviously)
+    #
+    # Example:
+    #   arr = ['a', 'b', 'c', 'd', 'e']
+    #   arr.extend(WillPaginate::ArrayMixin)
+    #   paged = arr.paginate(:per_page => 2)      #->  ['a', 'b']
+    #   paged.total_entries                       #->  5
+    #   arr.paginate(:page => 2, :per_page => 2)  #->  ['c', 'd']
+    #   arr.paginate(:page => 3, :per_page => 2)  #->  ['e']
+    #
+    # This method was originally {suggested by Desi
+    # McAdam}[http://www.desimcadam.com/archives/8] and later proved to be the
+    # most useful method of will_paginate library.
+    def paginate(options = {})
+      page     = options[:page] || 1
+      per_page = options[:per_page] || WillPaginate.per_page
+      total    = options[:total_entries] || self.length
+
+      WillPaginate::Collection.create(page, per_page, total) do |pager|
+        pager.replace self[pager.offset, pager.per_page].to_a
+      end
+    end
+  end
+end

--- a/lib/will_paginate/collection.rb
+++ b/lib/will_paginate/collection.rb
@@ -1,5 +1,6 @@
 require 'will_paginate/per_page'
 require 'will_paginate/page_number'
+require 'will_paginate/array_mixin'
 
 module WillPaginate
   # Any will_paginate-compatible collection should have these methods:


### PR DESCRIPTION
It is often suggested to `require 'will_paginate/array'` in order to paginate any arbitrary array, but changing a common class globally is often an anti-pattern which can lead to name clashes. Instead, one is encouraged to extend a particular object:

```ruby
array.extend(WillPaginate::ArrayMixin).paginate(page: page, per_page: per_page)
```

Note: this change is backward compatible

Perhaps, the module name is not the best, also may be `'will_paginate/array_mixin'` is required in a wrong place, I am open for any requests to change, please review.

Thanks.