### PR TITLE
Avoid extra query when total_entries has been provided

### DIFF
--- a/lib/will_paginate/view_helpers.rb
+++ b/lib/will_paginate/view_helpers.rb
@@ -104,7 +104,7 @@ module WillPaginate
     # The default output contains HTML. Use ":html => false" for plain text.
     def page_entries_info(collection, options = {})
       model = options[:model]
-      model = collection.first.class unless model or collection.empty?
+      model = collection.first.class unless model or collection.total_entries.zero?
       model ||= 'entry'
       model_key = if model.respond_to? :model_name
                     model.model_name.i18n_key  # ActiveModel::Naming


### PR DESCRIPTION
This removed a extra `count(*)` query when the total_entries has been provided. Related to issue #316

As a workaround, you can also pass the proper `model:` parameter to page_entries_info