### PR TITLE
Add support for Hanami

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # will_paginate
 
-will_paginate is a pagination library that integrates with Ruby on Rails, Sinatra, Merb, DataMapper and Sequel.
+will_paginate is a pagination library that integrates with Ruby on Rails, Sinatra, Hanami::View, Merb, DataMapper and Sequel.
 
 Installation:
 

--- a/lib/will_paginate/view_helpers/hanami.rb
+++ b/lib/will_paginate/view_helpers/hanami.rb
@@ -1,0 +1,41 @@
+require 'hanami/view'
+require 'will_paginate/view_helpers'
+require 'will_paginate/view_helpers/link_renderer'
+
+module WillPaginate
+  module Hanami
+    module Helpers
+      include ViewHelpers
+
+      def will_paginate(collection, options = {}) #:nodoc:
+        options = options.merge(:renderer => LinkRenderer) unless options[:renderer]
+        str = super(collection, options)
+        str && raw(str)
+      end
+    end
+
+    class LinkRenderer < ViewHelpers::LinkRenderer
+      protected
+
+      def url(page)
+        str = File.join(request_env['SCRIPT_NAME'].to_s, request_env['PATH_INFO'])
+        params = request_env['rack.request.query_hash'].merge(param_name.to_s => page.to_s)
+        params.update @options[:params] if @options[:params]
+        str << '?' << build_query(params)
+      end
+
+      def request_env
+        @template.params.env
+      end
+
+      def build_query(params)
+        Rack::Utils.build_nested_query params
+      end
+    end
+
+    def self.included(base)
+      base.include Helpers
+    end
+
+  end
+end

--- a/will_paginate.gemspec
+++ b/will_paginate.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version = WillPaginate::VERSION::STRING
   
   s.summary = "Pagination plugin for web frameworks and other apps"
-  s.description = "will_paginate provides a simple API for performing paginated queries with Active Record, DataMapper and Sequel, and includes helpers for rendering pagination links in Rails, Sinatra and Merb web apps."
+  s.description = "will_paginate provides a simple API for performing paginated queries with Active Record, DataMapper and Sequel, and includes helpers for rendering pagination links in Rails, Sinatra, Hanami, and Merb web apps."
   
   s.authors  = ['Mislav Marohnić']
   s.email    = 'mislav.marohnic@gmail.com'


### PR DESCRIPTION
This adds rendering support for Hanami, similar to Sinatra rendering.

This doesn't include ORM support for Hanami-Model, which is already well supported by [hanami-pagination](https://github.com/davydovanton/hanami-pagination). I think most projects using Hanami and its ORM would use hanami-pagination instead of will_paginate anyways.

This addition serves any Hanami project using Sequel or ActiveRecord (or array based paging). 

I added `Hanami::View` to the README and I will also make a PR to the Installation page of the wiki if this PR is accepted.