### PR TITLE
Fix wrong syntax in #paginated_section documentation

### DIFF
--- a/lib/will_paginate/view_helpers/action_view.rb
+++ b/lib/will_paginate/view_helpers/action_view.rb
@@ -43,7 +43,7 @@ module WillPaginate
     # Wrapper for rendering pagination links at both top and bottom of a block
     # of content.
     # 
-    #   <% paginated_section @posts do %>
+    #   <%= paginated_section @posts do %>
     #     <ol id="posts">
     #       <% for post in @posts %>
     #         <li> ... </li>


### PR DESCRIPTION
A small fix to documentation of the #paginated_section method.
`<%= ... %>` is the correct syntax.