### PR TITLE
Serve a 404 for unnested InvalidPage exceptions

### DIFF
--- a/lib/will_paginate/railtie.rb
+++ b/lib/will_paginate/railtie.rb
@@ -46,7 +46,7 @@ module WillPaginate
           exception
         end
 
-        if actual_exception.is_a?(WillPaginate::InvalidPage)
+        if exception.is_a?(WillPaginate::InvalidPage) || actual_exception.is_a?(WillPaginate::InvalidPage)
           Rack::Utils.status_code(:not_found)
         else
           original_method = method(:status_code_without_paginate)


### PR DESCRIPTION
If a `WillPaginate::InvalidPage` exception is raised in the context of a
Rails request, but it doesn't have a `cause` (or `original_exception`)
that is also a `WillPaginate::InvalidPage` exception, the intended
behavior of serving a 404 isn't observed. This regression appears to
have been introduced in [this commit][regression-commit].

Although `WillPaginate::PageNumber#initialize` does raise a nested
exception, and both it and its `cause` (they're the same thing) have
`InvalidPage` as an ancestor, in Ruby 2.2.3 the nested exception's
`#cause` is `nil`. This is most likely an instance of [this
bug][bug-12068], which was fixed in 2.4 and backported to later versions
of 2.2.x and 2.3.x.

See [this gist][repro] for a reproduction.

This commit fixes that behavior so that `WillPagiante::InvalidPage`
exceptions, regardless of their cause, will result in a 404. This will
also allow developers to raise a `WillPaginate::InvalidPage` exception
directly, with no cause (i.e. not via `WillPaginate::PageNumber.new`),
and achieve the same 404 behavior.

[bug-12068]: https://bugs.ruby-lang.org/issues/12068
[repro]: https://gist.github.com/english/25a0fe310b40237245b2911c15347e3a
[regression-commit]: https://github.com/mislav/will_paginate/commit/895e37b6fe6ff71ea5aac4afaae24837bf3f789a