### PR TITLE
Rename private method select_for_count to select_for_count_with_relation

### DIFF
--- a/lib/will_paginate/active_record.rb
+++ b/lib/will_paginate/active_record.rb
@@ -5,10 +5,10 @@ require 'active_record'
 
 module WillPaginate
   # = Paginating finders for ActiveRecord models
-  # 
+  #
   # WillPaginate adds +paginate+, +per_page+ and other methods to
   # ActiveRecord::Base class methods and associations.
-  # 
+  #
   # In short, paginating finders are equivalent to ActiveRecord finders; the
   # only difference is that we start with "paginate" instead of "find" and
   # that <tt>:page</tt> is required parameter:
@@ -83,7 +83,7 @@ module WillPaginate
           excluded = [:order, :limit, :offset, :reorder]
           excluded << :includes unless eager_loading?
           rel = self.except(*excluded)
-          column_name = (select_for_count(rel) || :all)
+          column_name = (select_for_count_with_relation(rel) || :all)
           rel.count(column_name)
         else
           super(*args)
@@ -136,8 +136,8 @@ module WillPaginate
         other.total_entries = nil if defined? @total_entries_queried
         other
       end
-      
-      def select_for_count(rel)
+
+      def select_for_count_with_relation(rel)
         if rel.select_values.present?
           select = rel.select_values.join(", ")
           select if select !~ /[,*]/
@@ -189,7 +189,7 @@ module WillPaginate
       # +per_page+.
       #
       # Example:
-      # 
+      #
       #   @developers = Developer.paginate_by_sql ['select * from developers where salary > ?', 80000],
       #                          :page => params[:page], :per_page => 3
       #
@@ -197,7 +197,7 @@ module WillPaginate
       # supply <tt>:total_entries</tt>. If you experience problems with this
       # generated SQL, you might want to perform the count manually in your
       # application.
-      # 
+      #
       def paginate_by_sql(sql, options)
         pagenum  = options.fetch(:page) { raise ArgumentError, ":page parameter required" } || 1
         per_page = options[:per_page] || self.per_page


### PR DESCRIPTION
`will_paginate` conflicts with Rails 6.0.0.beta2.

`will_paginate` redefines the private method `select_for_count` on ActiveRecord with a different number of arguments (the Rails private method accepts zero and `will_paginate` accepts one) causing an ArgumentError to be raised. Renaming this method prevents Rails from calling the method defined by `will_paginate`.

**Note:** This has been tested outside of will_paginate and has shown to resolve the conflict within our test suite, but I haven't been able to get the will_paginate tests to run (bundler version lock issues) or spend much time looking into what the problem with getting them to run is. If there are specific steps I can take to run the will_paginate tests prior to accepting this PR, I'm happy to follow them.