### PR TITLE
Fix circular require warning

### DIFF
--- a/lib/will_paginate/railtie.rb
+++ b/lib/will_paginate/railtie.rb
@@ -1,4 +1,3 @@
-require 'will_paginate'
 require 'will_paginate/page_number'
 require 'will_paginate/collection'
 require 'will_paginate/i18n'


### PR DESCRIPTION
Background:
As circular requires are considerend harmful and shows
warnings the one in `lib/will_paginate/railtie.rb` should be removed


Changes
- Remove circular require