### PR TITLE
ActiveRecord: Use total_entries in empty? to avoid a count query.

### DIFF
--- a/lib/will_paginate/active_record.rb
+++ b/lib/will_paginate/active_record.rb
@@ -105,9 +105,7 @@ module WillPaginate
       # overloaded to be pagination-aware
       def empty?
         if !loaded? and offset_value
-          result = count
-          result = result.size if result.respond_to?(:size) and !result.is_a?(Integer)
-          result <= offset_value
+          total_entries <= offset_value
         else
           super
         end

--- a/spec/finders/active_record_spec.rb
+++ b/spec/finders/active_record_spec.rb
@@ -163,6 +163,13 @@ describe WillPaginate::ActiveRecord do
       topics.total_entries.should == 999
     end
 
+    it "overrides empty? count call with a total_entries fixed value" do
+      lambda {
+        topics = Topic.paginate :page => 1, :per_page => 3, :total_entries => 999
+        topics.should_not be_empty
+      }.should run_queries(0)
+    end
+
     it "removes :include for count" do
       lambda {
         developers = Developer.paginate(:page => 1, :per_page => 1).includes(:projects)
@@ -271,12 +278,12 @@ describe WillPaginate::ActiveRecord do
     }.should run_queries(1)
   end
   
-  it "should get second (inexistent) page of Topics, requiring 2 queries" do
+  it "should get second (inexistent) page of Topics, requiring 1 query" do
     lambda {
       result = Topic.paginate :page => 2
       result.total_pages.should == 1
       result.should be_empty
-    }.should run_queries(2)
+    }.should run_queries(1)
   end
   
   describe "associations" do


### PR DESCRIPTION
In the past total_entries override was added to avoid count call in [this commit](https://github.com/mislav/will_paginate/commit/5d26795fe47fbee8211845e260c8c1d0b604be15#diff-7cb71655df7fd24cccb86712811f0fc8).

It is used like this:
```ruby
topics = Topic.paginate :page => 1, :per_page => 3, :total_entries => 999
```

`empty?` method still uses count query instead of `total_entries`. When I call following line in my code

```ruby
topics.empty?
```

it takes away all the advantages of custom `total_entries` setting by calling `count`.

Based on the original idea it should be safe to use `total_entries` also in `empty?` method.