### PR TITLE
Fix warnings on Ruby 2.7

### DIFF
--- a/lib/will_paginate/deprecation.rb
+++ b/lib/will_paginate/deprecation.rb
@@ -31,8 +31,8 @@ module WillPaginate::Deprecation
       super
     end
 
-    def deprecate_key(*keys)
-      message = block_given? ? Proc.new : keys.pop
+    def deprecate_key(*keys, &block)
+      message = block_given? ? block : keys.pop
       Array(keys).each { |key| @deprecated[key] = message }
     end
 


### PR DESCRIPTION
Ruby 2.7 emits warnings when using `Proc.new` with no block.  This
commit just converts the code to use `&block` to avoid the warning.