### PR TITLE
fix: actual_exception is NilClass when 'exception.cause' is nil.

### DIFF
--- a/lib/will_paginate/railtie.rb
+++ b/lib/will_paginate/railtie.rb
@@ -38,7 +38,7 @@ module WillPaginate
         alias_method :status_code, :status_code_with_paginate
       end
       def status_code_with_paginate(exception = @exception)
-        actual_exception = if exception.respond_to?(:cause)
+        actual_exception = if exception.respond_to?(:cause) && !exception.cause.nil?
           exception.cause
         elsif exception.respond_to?(:original_exception)
           exception.original_exception

--- a/lib/will_paginate/railtie.rb
+++ b/lib/will_paginate/railtie.rb
@@ -38,8 +38,8 @@ module WillPaginate
         alias_method :status_code, :status_code_with_paginate
       end
       def status_code_with_paginate(exception = @exception)
-        actual_exception = if exception.respond_to?(:cause) && !exception.cause.nil?
-          exception.cause
+        actual_exception = if exception.respond_to?(:cause)
+          exception.cause || exception
         elsif exception.respond_to?(:original_exception)
           exception.original_exception
         else


### PR DESCRIPTION
Dear  @mislav

This PR fixes a issue:
Status code is not 404 when 'WillPaginate::InvalidPage' is included in exception.

Reason:
Exception#cause return nil when previous exception is none.
 - https://ruby-doc.org/core-2.6/Exception.html#cause-method