### PR TITLE
Avoid extending Numeric

### DIFF
--- a/spec/page_number_spec.rb
+++ b/spec/page_number_spec.rb
@@ -37,7 +37,6 @@ describe WillPaginate::PageNumber do
 
     it "passes the Numeric=== type check" do |variable|
       (Numeric === num).should be
-      (Integer === num).should be
     end
   end
 


### PR DESCRIPTION
Extending this onto numeric slows down any case statement which is checking for any Numeric subclass (ie. `when Integer`, `when Float`).

Instead we can make PageNumber a proper subclass of Numeric. Doing this `Integer === page_number` is no longer true, but `Numeric === PageNumber` still is and hopefully that's sufficient.

cc @tenderlove @mislav 