### PR TITLE
Rails 6.0 & 6.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ gemfile:
   - Gemfile.rails5.0
   - Gemfile.rails5.1
   - Gemfile.rails5.2
+  - Gemfile.rails6.0
+  - Gemfile.rails6.1
   - Gemfile.rails-edge
 matrix:
   exclude:
@@ -95,3 +97,19 @@ matrix:
       gemfile: Gemfile.rails-edge
     - rvm: 2.4.5
       gemfile: Gemfile.rails-edge
+    - rvm: 2.1.8
+      gemfile: Gemfile.rails6.0
+    - rvm: 2.2.7
+      gemfile: Gemfile.rails6.0
+    - rvm: 2.3.8
+      gemfile: Gemfile.rails6.0
+    - rvm: 2.4.5
+      gemfile: Gemfile.rails6.0
+    - rvm: 2.1.8
+      gemfile: Gemfile.rails6.1
+    - rvm: 2.2.7
+      gemfile: Gemfile.rails6.1
+    - rvm: 2.3.8
+      gemfile: Gemfile.rails6.1
+    - rvm: 2.4.5
+      gemfile: Gemfile.rails6.1

--- a/Gemfile.rails-edge
+++ b/Gemfile.rails-edge
@@ -13,4 +13,4 @@ gem 'mocha', '~> 0.9.8'
 gem 'sqlite3', '~> 1.4.0'
 
 gem 'mysql2', '~> 0.5.2', :group => :mysql
-gem 'pg', '~> 0.11', :group => :pg
+gem 'pg', '~> 1.2', :group => :pg

--- a/Gemfile.rails6.0
+++ b/Gemfile.rails6.0
@@ -1,0 +1,14 @@
+source 'https://rubygems.org'
+
+rails_version = '~> 6.0.0'
+
+gem 'activerecord', rails_version
+gem 'actionpack',   rails_version
+
+gem 'rspec', '~> 2.99'
+gem 'mocha', '~> 0.9.8'
+
+gem 'sqlite3', '~> 1.4.0'
+
+gem 'mysql2', '~> 0.5.2', :group => :mysql
+gem 'pg', '~> 1.2', :group => :pg

--- a/Gemfile.rails6.1
+++ b/Gemfile.rails6.1
@@ -1,0 +1,14 @@
+source 'https://rubygems.org'
+
+rails_version = '~> 6.1.0'
+
+gem 'activerecord', rails_version
+gem 'actionpack',   rails_version
+
+gem 'rspec', '~> 2.99'
+gem 'mocha', '~> 0.9.8'
+
+gem 'sqlite3', '~> 1.4.0'
+
+gem 'mysql2', '~> 0.5.2', :group => :mysql
+gem 'pg', '~> 1.2', :group => :pg

--- a/lib/will_paginate/view_helpers.rb
+++ b/lib/will_paginate/view_helpers.rb
@@ -42,7 +42,7 @@ module WillPaginate
 
     # Returns HTML representing page links for a WillPaginate::Collection-like object.
     # In case there is no more than one page in total, nil is returned.
-    # 
+    #
     # ==== Options
     # * <tt>:class</tt> -- CSS class name for the generated DIV (default: "pagination")
     # * <tt>:previous_label</tt> -- default: "« Previous"
@@ -61,7 +61,7 @@ module WillPaginate
     #
     # All options not recognized by will_paginate will become HTML attributes on the container
     # element for pagination links (the DIV). For example:
-    # 
+    #
     #   <%= will_paginate @posts, :style => 'color:blue' %>
     #
     # will result in:
@@ -123,13 +123,15 @@ module WillPaginate
 
       model_count = collection.total_pages > 1 ? 5 : collection.size
       defaults = ["models.#{model_key}"]
-      defaults << Proc.new { |_, opts|
+      defaults << Proc.new { |opt1, opt2|
+        # we need this hack to support ruby 2.1
+        count = (opt2 && opt2.respond_to?(:[]) && opt2[:count]) || (opt1 && opt1.respond_to?(:[]) && opt1[:count])
         if model.respond_to? :model_name
-          model.model_name.human(:count => opts[:count])
+          model.model_name.human(:count => count)
         else
           name = model_key.to_s.tr('_', ' ')
           raise "can't pluralize model name: #{model.inspect}" unless name.respond_to? :pluralize
-          opts[:count] == 1 ? name : name.pluralize
+          count == 1 ? name : name.pluralize
         end
       }
       model_name = will_paginate_translate defaults, :count => model_count

--- a/lib/will_paginate/view_helpers/action_view.rb
+++ b/lib/will_paginate/view_helpers/action_view.rb
@@ -3,10 +3,10 @@ require 'will_paginate/view_helpers/link_renderer'
 
 module WillPaginate
   # = ActionView helpers
-  # 
+  #
   # This module serves for availability in ActionView templates. It also adds a new
   # view helper: +paginated_section+.
-  # 
+  #
   # == Using the helper without arguments
   # If the helper is called without passing in the collection object, it will
   # try to read from the instance variable inferred by the controller name.
@@ -42,7 +42,7 @@ module WillPaginate
 
     # Wrapper for rendering pagination links at both top and bottom of a block
     # of content.
-    # 
+    #
     #   <%= paginated_section @posts do %>
     #     <ol id="posts">
     #       <% for post in @posts %>
@@ -74,7 +74,7 @@ module WillPaginate
     def will_paginate_translate(keys, options = {})
       if respond_to? :translate
         if Array === keys
-          defaults = keys.dup
+          defaults = keys.map { |d| options && options[:count] && d.respond_to?(:call) ? d.call(options) : d }
           key = defaults.shift
         else
           defaults = nil


### PR DESCRIPTION
While rails < 6 used 2 arguments for defaults block, rails 6 use only 1 argument.

This patch makes the code runnable with both options

Connect replaygaming/replaypoker#4860
Close mislav/will_paginate#618