### PR TITLE
Added aria-disabled=true for disabled pagination

### DIFF
--- a/lib/will_paginate/view_helpers/link_renderer.rb
+++ b/lib/will_paginate/view_helpers/link_renderer.rb
@@ -71,7 +71,7 @@ module WillPaginate
         if page
           link(text, page, :class => classname)
         else
-          tag(:span, text, :class => classname + ' disabled')
+          tag(:span, text, :class => classname + ' disabled', :"aria-disabled" => true)
         end
       end
       


### PR DESCRIPTION
This accurately represents the role of the button for screen reader purposes, and should allow pages that paginate with will_paginate to pass accessibility tests.