### PR TITLE
Remove `aria-disabled` attribute from SPAN element

### DIFF
--- a/lib/will_paginate/view_helpers/link_renderer.rb
+++ b/lib/will_paginate/view_helpers/link_renderer.rb
@@ -71,7 +71,7 @@ module WillPaginate
         if page
           link(text, page, :class => classname)
         else
-          tag(:span, text, :class => classname + ' disabled', :"aria-disabled" => true)
+          tag(:span, text, :class => classname + ' disabled')
         end
       end
       

--- a/spec/view_helpers/action_view_spec.rb
+++ b/spec/view_helpers/action_view_spec.rb
@@ -127,7 +127,7 @@ describe WillPaginate::ActionView do
   it "should match expected markup" do
     paginate
     expected = <<-HTML
-      <div class="pagination" role="navigation" aria-label="Pagination"><span class="previous_page disabled" aria-disabled="true">&#8592; Previous</span>
+      <div class="pagination" role="navigation" aria-label="Pagination"><span class="previous_page disabled">&#8592; Previous</span>
       <em class="current" aria-label="Page 1" aria-current="page">1</em>
       <a href="/foo/bar?page=2" aria-label="Page 2" rel="next">2</a>
       <a href="/foo/bar?page=3" aria-label="Page 3">3</a>


### PR DESCRIPTION
An ARIA compliance tool issues a warning that `aria-disabled` is not appropriate for the "generic" role of the SPAN element.

Reverts #621
Fixes https://github.com/mislav/will_paginate/issues/632