### PR TITLE
Remove unneeded files from the gem package

### DIFF
--- a/will_paginate.gemspec
+++ b/will_paginate.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ['--main', 'README.md', '--charset=UTF-8']
   s.extra_rdoc_files = ['README.md', 'LICENSE']
   
-  s.files = Dir['Rakefile', '{bin,lib,test,spec}/**/*', 'README*', 'LICENSE*']
+  s.files = Dir['lib/**/*', 'README*', 'LICENSE*']
 
   # include only files in version control
   git_dir = File.expand_path('../.git', __FILE__)


### PR DESCRIPTION
There are a bunch of files in the gem package that aren't useful for downstream projects. Removing these reduces the gem package size from **33K** to **19K**!

<details><summary>gem contents diff</summary>

```diff
  LICENSE
  README.md
  lib/will_paginate.rb
  lib/will_paginate/active_record.rb
  lib/will_paginate/array.rb
  lib/will_paginate/collection.rb
  lib/will_paginate/core_ext.rb
  lib/will_paginate/deprecation.rb
  lib/will_paginate/i18n.rb
  lib/will_paginate/locale/en.yml
  lib/will_paginate/mongoid.rb
  lib/will_paginate/page_number.rb
  lib/will_paginate/per_page.rb
  lib/will_paginate/railtie.rb
  lib/will_paginate/sequel.rb
  lib/will_paginate/version.rb
  lib/will_paginate/view_helpers.rb
  lib/will_paginate/view_helpers/action_view.rb
  lib/will_paginate/view_helpers/hanami.rb
  lib/will_paginate/view_helpers/link_renderer.rb
  lib/will_paginate/view_helpers/link_renderer_base.rb
  lib/will_paginate/view_helpers/sinatra.rb
< spec/collection_spec.rb
< spec/console
< spec/console_fixtures.rb
< spec/database.yml
< spec/finders/active_record_spec.rb
< spec/finders/activerecord_test_connector.rb
< spec/fixtures/admin.rb
< spec/fixtures/developer.rb
< spec/fixtures/developers_projects.yml
< spec/fixtures/project.rb
< spec/fixtures/projects.yml
< spec/fixtures/replies.yml
< spec/fixtures/reply.rb
< spec/fixtures/schema.rb
< spec/fixtures/topic.rb
< spec/fixtures/topics.yml
< spec/fixtures/user.rb
< spec/fixtures/users.yml
< spec/matchers/query_count_matcher.rb
< spec/page_number_spec.rb
< spec/per_page_spec.rb
< spec/spec_helper.rb
< spec/view_helpers/action_view_spec.rb
< spec/view_helpers/base_spec.rb
< spec/view_helpers/link_renderer_base_spec.rb
< spec/view_helpers/view_example_group.rb
```

</details>