### PR TITLE
Add aria-label for previous and next page links

### DIFF
--- a/lib/will_paginate/locale/en.yml
+++ b/lib/will_paginate/locale/en.yml
@@ -1,7 +1,9 @@
 en:
   will_paginate:
     previous_label: "&#8592; Previous"
+    previous_aria_label: "Previous page"
     next_label: "Next &#8594;"
+    next_aria_label: "Next page"
     page_gap: "&hellip;"
     container_aria_label: "Pagination"
     page_aria_label: "Page %{page}"

--- a/lib/will_paginate/view_helpers/link_renderer.rb
+++ b/lib/will_paginate/view_helpers/link_renderer.rb
@@ -69,7 +69,7 @@ module WillPaginate
       
       def previous_or_next_page(page, text, classname)
         if page
-          link(text, page, :class => classname)
+          link(text, page, :class => classname, :'aria-label' => "#{classname.split('_').first} page")
         else
           tag(:span, text, :class => classname + ' disabled')
         end

--- a/lib/will_paginate/view_helpers/link_renderer.rb
+++ b/lib/will_paginate/view_helpers/link_renderer.rb
@@ -59,19 +59,21 @@ module WillPaginate
       
       def previous_page
         num = @collection.current_page > 1 && @collection.current_page - 1
-        previous_or_next_page(num, @options[:previous_label], 'previous_page')
+        aria_label = @template.will_paginate_translate(:previous_aria_label) { "Previous page" }
+        previous_or_next_page(num, @options[:previous_label], 'previous_page', aria_label)
       end
       
       def next_page
         num = @collection.current_page < total_pages && @collection.current_page + 1
-        previous_or_next_page(num, @options[:next_label], 'next_page')
+        aria_label = @template.will_paginate_translate(:next_aria_label) { "Next page" }
+        previous_or_next_page(num, @options[:next_label], 'next_page', aria_label)
       end
       
-      def previous_or_next_page(page, text, classname)
+      def previous_or_next_page(page, text, classname, aria_label = nil)
         if page
-          link(text, page, :class => classname, :'aria-label' => "#{classname.split('_').first} page")
+          link(text, page, :class => classname, :'aria-label' => aria_label)
         else
-          tag(:span, text, :class => classname + ' disabled')
+          tag(:span, text, :class => classname + ' disabled', :'aria-label' => aria_label)
         end
       end
       

--- a/spec/view_helpers/action_view_spec.rb
+++ b/spec/view_helpers/action_view_spec.rb
@@ -127,11 +127,11 @@ RSpec.describe WillPaginate::ActionView do
   it "should match expected markup" do
     paginate
     expected = <<-HTML
-      <div class="pagination" role="navigation" aria-label="Pagination"><span class="previous_page disabled">&#8592; Previous</span>
+      <div class="pagination" role="navigation" aria-label="Pagination"><span class="previous_page disabled" aria-label="Previous page">&#8592; Previous</span>
       <em class="current" aria-label="Page 1" aria-current="page">1</em>
       <a href="/foo/bar?page=2" aria-label="Page 2" rel="next">2</a>
       <a href="/foo/bar?page=3" aria-label="Page 3">3</a>
-      <a href="/foo/bar?page=2" class="next_page" rel="next">Next &#8594;</a></div>
+      <a href="/foo/bar?page=2" class="next_page" rel="next" aria-label="Next page">Next &#8594;</a></div>
     HTML
     expected.strip!.gsub!(/\s{2,}/, ' ')
     expected_dom = parse_html_document(expected)


### PR DESCRIPTION
We have a product named EZOfficeInventory (https://www.ezofficeinventory.com). In this product, we are using will_paginate gem to provide pagination to our clients.

BBC News is one of our clients. We noticed that when we focus on previous or next page icons then the screen reader just read them as just "link" instead of the previous or next page. It creates confusion for the person with a vision disability.

Now we are now adding an aria-label class with those two link buttons so they can be called correctly.