### PR TITLE
Fix running with RUBYOPT="--enable-frozen-string-literal"

### DIFF
--- a/lib/will_paginate/view_helpers/link_renderer.rb
+++ b/lib/will_paginate/view_helpers/link_renderer.rb
@@ -103,7 +103,7 @@ module WillPaginate
       end
       
       def tag(name, value, attributes = {})
-        string_attributes = attributes.inject('') do |attrs, pair|
+        string_attributes = attributes.inject(''.dup) do |attrs, pair|
           unless pair.last.nil?
             attrs << %( #{pair.first}="#{CGI::escapeHTML(pair.last.to_s)}")
           end

--- a/spec/view_helpers/action_view_spec.rb
+++ b/spec/view_helpers/action_view_spec.rb
@@ -126,14 +126,13 @@ RSpec.describe WillPaginate::ActionView do
 
   it "should match expected markup" do
     paginate
-    expected = <<-HTML
+    expected = <<-HTML.strip.gsub(/\s{2,}/, ' ')
       <div class="pagination" role="navigation" aria-label="Pagination"><span class="previous_page disabled" aria-label="Previous page">&#8592; Previous</span>
       <em class="current" aria-label="Page 1" aria-current="page">1</em>
       <a href="/foo/bar?page=2" aria-label="Page 2" rel="next">2</a>
       <a href="/foo/bar?page=3" aria-label="Page 3">3</a>
       <a href="/foo/bar?page=2" class="next_page" rel="next" aria-label="Next page">Next &#8594;</a></div>
     HTML
-    expected.strip!.gsub!(/\s{2,}/, ' ')
     expected_dom = parse_html_document(expected)
 
     if expected_dom.respond_to?(:canonicalize)


### PR DESCRIPTION
This adds a small fix that avoids a FrozenError if you're running your app with `--enable-frozen-string-literal`.

If you like I could also add it to script/test_all to avoid any future regressions?