### PR TITLE
Fix total_pages method fail on active_record model after calling merge with unscoped limit

### DIFF
--- a/lib/will_paginate/active_record.rb
+++ b/lib/will_paginate/active_record.rb
@@ -5,10 +5,10 @@ require 'active_record'
 
 module WillPaginate
   # = Paginating finders for ActiveRecord models
-  # 
+  #
   # WillPaginate adds +paginate+, +per_page+ and other methods to
   # ActiveRecord::Base class methods and associations.
-  # 
+  #
   # In short, paginating finders are equivalent to ActiveRecord finders; the
   # only difference is that we start with "paginate" instead of "find" and
   # that <tt>:page</tt> is required parameter:
@@ -24,7 +24,7 @@ module WillPaginate
       attr_writer :total_entries
 
       def per_page(value = nil)
-        if value.nil? then limit_value
+        if value.nil? then limit_value || total_entries
         else limit(value)
         end
       end
@@ -67,7 +67,7 @@ module WillPaginate
 
       def total_entries
         @total_entries ||= begin
-          if loaded? and size < limit_value and (current_page == 1 or size > 0)
+          if loaded? and limit_value and size < limit_value and (current_page == 1 or size > 0)
             offset_value + size
           else
             @total_entries_queried = true
@@ -183,7 +183,7 @@ module WillPaginate
       # +per_page+.
       #
       # Example:
-      # 
+      #
       #   @developers = Developer.paginate_by_sql ['select * from developers where salary > ?', 80000],
       #                          :page => params[:page], :per_page => 3
       #
@@ -191,7 +191,7 @@ module WillPaginate
       # supply <tt>:total_entries</tt>. If you experience problems with this
       # generated SQL, you might want to perform the count manually in your
       # application.
-      # 
+      #
       def paginate_by_sql(sql, options)
         pagenum  = options.fetch(:page) { raise ArgumentError, ":page parameter required" } || 1
         per_page = options[:per_page] || self.per_page


### PR DESCRIPTION
It appeared that using active record `.merge` can lead to having `.limit_value` as `nil`, which causes `.total_entries` and `.total_pages` fail with the error `comparison of Integer with nil failed` on [will_paginate/active_record.rb:70](https://github.com/mislav/will_paginate/blob/573df2d9c36ca2b4c2f1fe139f4e25fba30d0af4/lib/will_paginate/active_record.rb#L70)

Here is an example of how you can get `nil` value in `limit_value` field:
```ruby
User.limit(10).limit_value
# => 10
User.joins(:role).limit(10).merge(Role.all.unscope(:limit)).limit_value
# => nil
```

Totally there are 2 places that required updates:

- in `total_entries` method in `active_record.rb`, that fails when `limit_value` as `nil` value is compared to the size https://github.com/allomov/will_paginate/blob/53e08fe99b4bbfa67213ac28734871bacb59e343/lib/will_paginate/active_record.rb#L70
- in `per_page` method  `limit_value` as `nil` can cause issues while computing `.total_pages` https://github.com/allomov/will_paginate/blob/53e08fe99b4bbfa67213ac28734871bacb59e343/lib/will_paginate/active_record.rb#L27