### PR TITLE
Add documentation specifying the per_page default of 30.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ class Post
   self.per_page = 10
 end
 
-# set per_page globally
+# set per_page globally (If this setting is left unspecified the default value is 30)
 WillPaginate.per_page = 10
 ```
 


### PR DESCRIPTION
Adding [default per_page ](https://github.com/mislav/will_paginate/blob/master/lib/will_paginate/per_page.rb#L25-L26)to documentation to make it more explicit for developers.

