### PR TITLE
Pass a block to Proc.new for ruby 3.x compatibility

### DIFF
--- a/lib/will_paginate/i18n.rb
+++ b/lib/will_paginate/i18n.rb
@@ -16,7 +16,7 @@ module WillPaginate
             # procs in defaults array were not supported back then
             defaults << yield(defaults.first, options)
           else
-            defaults << Proc.new
+            defaults << Proc.new {}
           end
         end
         ::I18n.translate(defaults.shift, options.merge(:default => defaults, :scope => :will_paginate))


### PR DESCRIPTION
ruby 3.x requires a block to be given when creating a new proc.