### PR TITLE
Add support for lambda in `total_entries` option

### DIFF
--- a/lib/will_paginate/active_record.rb
+++ b/lib/will_paginate/active_record.rb
@@ -67,14 +67,28 @@ module WillPaginate
 
       def total_entries
         @total_entries ||= begin
-          if loaded? and size < limit_value and (current_page == 1 or size > 0)
+          if loaded? && size < limit_value && (current_page == 1 || size > 0)
             offset_value + size
           else
             @total_entries_queried = true
-            result = count
-            result = result.size if result.respond_to?(:size) and !result.is_a?(Integer)
-            result
+            if @total_entries_lambda
+              @total_entries_lambda.call
+            else
+              result = count
+              result = result.size if result.respond_to?(:size) && !result.is_a?(Integer)
+              result
+            end
           end
+        end
+      end
+
+      def total_entries=(value)
+        if value.respond_to?(:call)
+          @total_entries_lambda = value
+          @total_entries = nil
+        else
+          @total_entries_lambda = nil
+          @total_entries = value.blank? ? nil : value.to_i
         end
       end
 
@@ -152,7 +166,7 @@ module WillPaginate
         end
 
         rel = limit(per_page.to_i).page(pagenum)
-        rel.total_entries = total.to_i          unless total.blank?
+        rel.total_entries = total unless total.blank?
         rel
       end
 

--- a/spec/finders/active_record_spec.rb
+++ b/spec/finders/active_record_spec.rb
@@ -421,4 +421,27 @@ RSpec.describe WillPaginate::ActiveRecord do
       Project.page(307445734561825862)
     }.to raise_error(WillPaginate::InvalidPage, "invalid offset: 9223372036854775830")
   end
- end
+
+  describe "total_entries with lambda" do
+    it "executes the lambda when needed" do
+      lambda_called = false
+      total_entries_lambda = -> { lambda_called = true; 100 }
+
+      topics = Topic.paginate :page => 1, :per_page => 3, :total_entries => total_entries_lambda
+
+      expect(topics.total_entries).to eq(100)
+      expect(lambda_called).to be true
+    end
+
+    it "does not execute the lambda when optimization applies" do
+      lambda_called = false
+      total_entries_lambda = -> { lambda_called = true; 100 }
+
+      topics = Topic.paginate :page => 1, :per_page => 10, :total_entries => total_entries_lambda
+
+      # Assuming the first batch size is smaller than the limit (10)
+      expect(topics.size).to be < 10
+      expect(lambda_called).to be false
+    end
+  end
+end


### PR DESCRIPTION
We use the `total_entries` option to avoid doing expensive count queries (instead we run queries that limit the number of records examined, because we don't care about exact numbers above a certain amount). But we still want to retain the optimization that no query is run at all if the first page's query returns few enough records that we know we've read all of them.

Hence add support for the `total_entries` option being passed as a lambda.

- Updated the `total_entries` logic to allow passing a lambda that is executed only when necessary.
- Retained the optimization to skip execution of the lambda when the first batch size is smaller than the limit.
- Centralized the handling of `total_entries` values (both lambdas and direct values) in the `total_entries=` setter.

Note: this code was authored with the help of Copilot and GPT-4o. That being said, I reviewed the resulting code, and I also applied various stylistic edits/refactors to the resulting code.